### PR TITLE
Fix header manipulation to Custom Endpoints

### DIFF
--- a/endpoints/client_endpoints.go
+++ b/endpoints/client_endpoints.go
@@ -88,6 +88,9 @@ func jsonEndpointToEndpoint(jsonEndpoint map[string]interface{}) Endpoint {
 		headers := strings.Split(headerString, ",")
 		for _, header := range headers {
 			kv := strings.Split(header, "=")
+			if len(kv) <= 1 {
+				continue
+			}
 			headerMap[kv[0]] = kv[1]
 		}
 		endpoint.Headers = headerMap


### PR DESCRIPTION
Neither all the Custom endpoints have header definition which means that
the provider expected use the values in the header to set headerMap
causing TERRAFORM CRASH when terraform tried to check the current state
of endpoints already existents.

To work around it in the previous version we were forced to set faked
headers to avoid "Out of index error" and this handling purpose to avoid
this inconvenience.