### PR TITLE
1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ endpoint, err := underTest.CreateEndpoint(endpoints.Endpoint{
 
 ### Changelog
 - v1.5.2
-    - Fix custom endpoint-empty headers bug.
+    - Fix `custom endpoint` -empty headers bug.
+    - Allow empty array for sharing accounts in `sub account`.
 - v1.5.1
     - Fix alerts_v2 sort bug.
 - v1.5

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ endpoint, err := underTest.CreateEndpoint(endpoints.Endpoint{
 
 
 ### Changelog
+- v1.5.2
+    - Fix custom endpoint-empty headers bug.
 - v1.5.1
     - Fix alerts_v2 sort bug.
 - v1.5

--- a/endpoints/client_endpoints.go
+++ b/endpoints/client_endpoints.go
@@ -83,14 +83,18 @@ func jsonEndpointToEndpoint(jsonEndpoint map[string]interface{}) Endpoint {
 	case EndpointTypeCustom:
 		endpoint.Url = jsonEndpoint[fldEndpointUrl].(string)
 		endpoint.BodyTemplate = jsonEndpoint[fldEndpointBodyTemplate]
-		headerMap := make(map[string]string)
-		headerString := jsonEndpoint[fldEndpointHeaders].(string)
-		headers := strings.Split(headerString, ",")
-		for _, header := range headers {
-			kv := strings.Split(header, "=")
-			headerMap[kv[0]] = kv[1]
+		if jsonEndpoint[fldEndpointHeaders] != nil {
+			headerMap := make(map[string]string)
+			headerString := jsonEndpoint[fldEndpointHeaders].(string)
+			headers := strings.Split(headerString, ",")
+			for _, header := range headers {
+				kv := strings.Split(header, "=")
+				headerMap[kv[0]] = kv[1]
+			}
+
+			endpoint.Headers = headerMap
 		}
-		endpoint.Headers = headerMap
+
 		endpoint.Method = jsonEndpoint[fldEndpointMethod].(string)
 	case EndpointTypePagerDuty:
 		endpoint.ServiceKey = jsonEndpoint[fldEndpointServiceKey].(string)

--- a/endpoints/client_endpoints_create.go
+++ b/endpoints/client_endpoints_create.go
@@ -32,13 +32,16 @@ func buildCreateEndpointRequest(endpoint Endpoint) map[string]interface{} {
 	if endpoint.EndpointType == EndpointTypeCustom {
 		createEndpoint[fldEndpointUrl] = endpoint.Url
 		createEndpoint[fldEndpointMethod] = endpoint.Method
-		headers := endpoint.Headers
-		headerStrings := []string{}
-		for k, v := range headers {
-			headerStrings = append(headerStrings, fmt.Sprintf("%s=%s", k, v))
+		if endpoint.Headers != nil && len(endpoint.Headers) > 0 {
+			headers := endpoint.Headers
+			headerStrings := []string{}
+			for k, v := range headers {
+				headerStrings = append(headerStrings, fmt.Sprintf("%s=%s", k, v))
+			}
+			headerString := strings.Join(headerStrings, ",")
+			createEndpoint[fldEndpointHeaders] = headerString
 		}
-		headerString := strings.Join(headerStrings, ",")
-		createEndpoint[fldEndpointHeaders] = headerString
+
 		createEndpoint[fldEndpointBodyTemplate] = endpoint.BodyTemplate
 	}
 

--- a/endpoints/endpoints_custom_integration_test.go
+++ b/endpoints/endpoints_custom_integration_test.go
@@ -79,13 +79,10 @@ func TestIntegrationEndpoints_CustomCreateNoHeader(t *testing.T) {
 			BodyTemplate: map[string]string{"hello": "there", "header": "two"},
 		})
 
-		if endpoint != nil {
+		if assert.NotNil(t, endpoint) && assert.NoError(t, err) {
+			assert.NotEmpty(t, endpoint.Id)
 			defer underTest.DeleteEndpoint(endpoint.Id)
 		}
-
-		assert.NotNil(t, endpoint)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, endpoint.Id)
 	}
 }
 
@@ -101,20 +98,41 @@ func TestIntegrationEndpoints_CustomGetNoHeaders(t *testing.T) {
 			BodyTemplate: map[string]string{"hello": "there", "header": "two"},
 		})
 
-		if endpoint != nil {
+		if assert.NotNil(t, endpoint) && assert.NoError(t, err) {
 			defer underTest.DeleteEndpoint(endpoint.Id)
+			assert.NotEmpty(t, endpoint.Id)
+			time.Sleep(4 * time.Second)
+			getEndpoint, err := underTest.GetEndpoint(endpoint.Id)
+			assert.NotNil(t, endpoint)
+			assert.NoError(t, err)
+			assert.Equal(t, endpoint.Id, getEndpoint.Id)
 		}
+	}
+}
 
-		assert.NotNil(t, endpoint)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, endpoint.Id)
+func TestIntegrationEndpoints_CustomCreateInvalidMethod(t *testing.T) {
+	underTest, err := setupEndpointsIntegrationTest()
+	if assert.NoError(t, err) {
+		endpoint, err := underTest.CreateEndpoint(endpoints.Endpoint{
+			Title:        "testCreateCustomEndpoint",
+			Method:       "INVALID",
+			Description:  "my description",
+			Url:          "https://jsonplaceholder.typicode.com/todos/1",
+			EndpointType: "custom",
+			Headers:      map[string]string{"hello": "there", "header": "two"},
+			BodyTemplate: map[string]string{"hello": "there", "header": "two"},
+		})
 
-		time.Sleep(4 * time.Second)
+		assert.Error(t, err)
+		assert.Nil(t, endpoint)
+	}
+}
 
-		getEndpoint, err := underTest.GetEndpoint(endpoint.Id)
-
-		assert.NotNil(t, endpoint)
-		assert.NoError(t, err)
-		assert.Equal(t, endpoint.Id, getEndpoint.Id)
+func TestIntegrationEndpoints_CustomGetNotExists(t *testing.T) {
+	underTest, err := setupEndpointsIntegrationTest()
+	if assert.NoError(t, err) {
+		endpoint, err := underTest.GetEndpoint(int64(1234567))
+		assert.Error(t, err)
+		assert.Nil(t, endpoint)
 	}
 }

--- a/endpoints/endpoints_custom_integration_test.go
+++ b/endpoints/endpoints_custom_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestIntegrationEndpoints_CustomCreateUpdate(t *testing.T) {
@@ -63,5 +64,57 @@ func TestIntegrationEndpoints_CustomCreateDuplicate(t *testing.T) {
 			assert.Nil(t, duplicate)
 			assert.Error(t, err)
 		}
+	}
+}
+
+func TestIntegrationEndpoints_CustomCreateNoHeader(t *testing.T) {
+	underTest, err := setupEndpointsIntegrationTest()
+	if assert.NoError(t, err) {
+		endpoint, err := underTest.CreateEndpoint(endpoints.Endpoint{
+			Title:        "testCreateCustomEndpointNoHeaders",
+			Method:       "POST",
+			Description:  "my description",
+			Url:          "https://jsonplaceholder.typicode.com/todos/1",
+			EndpointType: "custom",
+			BodyTemplate: map[string]string{"hello": "there", "header": "two"},
+		})
+
+		if endpoint != nil {
+			defer underTest.DeleteEndpoint(endpoint.Id)
+		}
+
+		assert.NotNil(t, endpoint)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, endpoint.Id)
+	}
+}
+
+func TestIntegrationEndpoints_CustomGetNoHeaders(t *testing.T) {
+	underTest, err := setupEndpointsIntegrationTest()
+	if assert.NoError(t, err) {
+		endpoint, err := underTest.CreateEndpoint(endpoints.Endpoint{
+			Title:        "testCreateCustomEndpointNoHeaders",
+			Method:       "POST",
+			Description:  "my description",
+			Url:          "https://jsonplaceholder.typicode.com/todos/1",
+			EndpointType: "custom",
+			BodyTemplate: map[string]string{"hello": "there", "header": "two"},
+		})
+
+		if endpoint != nil {
+			defer underTest.DeleteEndpoint(endpoint.Id)
+		}
+
+		assert.NotNil(t, endpoint)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, endpoint.Id)
+
+		time.Sleep(4 * time.Second)
+
+		getEndpoint, err := underTest.GetEndpoint(endpoint.Id)
+
+		assert.NotNil(t, endpoint)
+		assert.NoError(t, err)
+		assert.Equal(t, endpoint.Id, getEndpoint.Id)
 	}
 }

--- a/sub_accounts/client_sub_account_create.go
+++ b/sub_accounts/client_sub_account_create.go
@@ -15,6 +15,10 @@ const (
 )
 
 func (c *SubAccountClient) createApiRequest(apiToken string, s SubAccountCreate) (*http.Request, error) {
+	if s.SharingObjectAccounts == nil {
+		s.SharingObjectAccounts = make([]int32, 0)
+	}
+
 	var (
 		createSubAccount = map[string]interface{}{
 			"email":                  s.Email,

--- a/sub_accounts/client_sub_account_update.go
+++ b/sub_accounts/client_sub_account_update.go
@@ -21,6 +21,10 @@ func (c *SubAccountClient) updateValidateRequest(id int64) (error, bool) {
 }
 
 func (c *SubAccountClient) updateApiRequest(apiToken string, id int64, subAccount SubAccount) (*http.Request, error) {
+	if subAccount.SharingObjectAccounts == nil {
+		subAccount.SharingObjectAccounts = make([]interface{}, 0)
+	}
+
 	var (
 		updateUser = map[string]interface{}{
 			//"email":                  subAccount.Email,

--- a/sub_accounts/sub_account_create_integration_test.go
+++ b/sub_accounts/sub_account_create_integration_test.go
@@ -1,0 +1,81 @@
+package sub_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/sub_accounts"
+	"github.com/logzio/logzio_terraform_client/test_utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSubAccount_CreateSubAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err){
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_create",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteSubAccount(subAccount.Id)
+		}
+	}
+}
+
+func TestIntegrationSubAccount_CreateSubAccountWithSharingAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err){
+		accountId, err := test_utils.GetAccountId()
+		assert.NoError(t, err)
+
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_create_sharing_account",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{int32(accountId)},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteSubAccount(subAccount.Id)
+		}
+	}
+}
+
+func TestIntegrationSubAccount_CreateSubAccountInvalidMail(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err){
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 "invalid@mail.com",
+			AccountName:           "test_create",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}

--- a/sub_accounts/sub_account_create_test.go
+++ b/sub_accounts/sub_account_create_test.go
@@ -60,3 +60,52 @@ func TestSubAccount_CreateValidSubAccount(t *testing.T) {
 	assert.NotNil(t, subAccount)
 	assert.NotZero(t, subAccount.Id)
 }
+
+func TestSubAccount_CreateValidSubAccountEmptySharingObjectAccount(t *testing.T) {
+	underTest, err, teardown := setupSubAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	mux.HandleFunc("/v1/account-management/time-based-accounts", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		var target map[string]interface{}
+		err = json.Unmarshal(jsonBytes, &target)
+		assert.Contains(t, target, "email")
+		assert.Contains(t, target, "accountName")
+		assert.Contains(t, target, "maxDailyGB")
+		assert.Contains(t, target, "retentionDays")
+		assert.Contains(t, target, "searchable")
+		assert.Contains(t, target, "accessible")
+		assert.Contains(t, target, "sharingObjectsAccounts")
+		assert.Contains(t, target, "docSizeSetting")
+		assert.Contains(t, target, "utilizationSettings")
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("create_subaccount.json"))
+	})
+
+	var sharingAccounts []int32
+
+	utilizationSettings := make(map[string]interface{}, 2)
+	utilizationSettings["a"] = "v"
+
+	s := sub_accounts.SubAccountCreate{
+		Email:                 "test.user@test.user",
+		AccountName:           "some account name",
+		MaxDailyGB:            10.5,
+		RetentionDays:         10,
+		Searchable:            true,
+		Accessible:            false,
+		SharingObjectAccounts: sharingAccounts,
+		DocSizeSetting:        true,
+		UtilizationSettings:   utilizationSettings,
+	}
+
+	subAccount, err := underTest.CreateSubAccount(s)
+	assert.NoError(t, err)
+	assert.NotNil(t, subAccount)
+	assert.NotZero(t, subAccount.Id)
+}

--- a/sub_accounts/sub_account_delete_integration_test.go
+++ b/sub_accounts/sub_account_delete_integration_test.go
@@ -1,0 +1,44 @@
+package sub_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/sub_accounts"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSubAccount_DeleteSubAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err){
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_delete",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer func() {
+				err = underTest.DeleteSubAccount(subAccount.Id)
+				assert.NoError(t, err)
+			}()
+
+		}
+	}
+}
+
+func TestIntegrationSubAccount_DeleteSubAccountNotExists(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		err = underTest.DeleteSubAccount(int64(1234567))
+		assert.Error(t, err)
+	}
+}

--- a/sub_accounts/sub_account_get_detailed_integration_test.go
+++ b/sub_accounts/sub_account_get_detailed_integration_test.go
@@ -1,0 +1,45 @@
+package sub_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/sub_accounts"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSubAccount_GetDetailedSubAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_get_detailed",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			defer underTest.DeleteSubAccount(subAccount.Id)
+			time.Sleep(4 * time.Second)
+			getSubAccount, err := underTest.GetDetailedSubAccount(subAccount.Id)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, getSubAccount)
+		}
+	}
+}
+
+func TestIntegrationSubAccount_GetDetailedSubAccountNotExists(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		subAccount, err := underTest.GetDetailedSubAccount(int64(1234567))
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}

--- a/sub_accounts/sub_account_get_integration_test.go
+++ b/sub_accounts/sub_account_get_integration_test.go
@@ -1,0 +1,47 @@
+package sub_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/sub_accounts"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSubAccount_GetSubAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_get",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			defer underTest.DeleteSubAccount(subAccount.Id)
+			time.Sleep(4 * time.Second)
+			getSubAccount, err := underTest.GetSubAccount(subAccount.Id)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, getSubAccount)
+			assert.Equal(t, subAccount.Id, getSubAccount.Id)
+			assert.Equal(t, subAccount.AccountName, getSubAccount.AccountName)
+		}
+	}
+}
+
+func TestIntegrationSubAccount_GetSubAccountNotExists(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		subAccount, err := underTest.GetSubAccount(int64(1234567))
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}

--- a/sub_accounts/sub_account_list_detailed_integration_test.go
+++ b/sub_accounts/sub_account_list_detailed_integration_test.go
@@ -1,0 +1,15 @@
+package sub_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIntegrationSubAccount_ListDetailedSubAccounts(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		_, err = underTest.DetailedSubAccounts()
+		assert.NoError(t, err)
+	}
+}

--- a/sub_accounts/sub_account_list_integration_test.go
+++ b/sub_accounts/sub_account_list_integration_test.go
@@ -1,0 +1,15 @@
+package sub_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIntegrationSubAccount_ListSubAccounts(t *testing.T) {
+	underTest, _, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		_, err = underTest.ListSubAccounts()
+		assert.NoError(t, err)
+	}
+}

--- a/sub_accounts/sub_account_test.go
+++ b/sub_accounts/sub_account_test.go
@@ -33,12 +33,17 @@ func setupSubAccountsTest() (*sub_accounts.SubAccountClient, error, func()) {
 	}
 }
 
-func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, error) {
+func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, string, error) {
 	apiToken, err := test_utils.GetApiToken()
 	if err != nil {
-		return nil, err
+		return nil, "", err
+	}
+
+	email, err := test_utils.GetLogzioEmail()
+	if err != nil {
+		return nil, "", err
 	}
 
 	underTest, err := sub_accounts.New(apiToken, test_utils.GetLogzIoBaseUrl())
-	return underTest, err
+	return underTest, email, err
 }

--- a/sub_accounts/sub_account_update_integration_test.go
+++ b/sub_accounts/sub_account_update_integration_test.go
@@ -1,0 +1,35 @@
+package sub_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/sub_accounts"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSubAccount_UpdateSubAccount(t *testing.T) {
+	underTest, email, err := setupSubAccountsIntegrationTest()
+
+	if assert.NoError(t, err){
+		createSubAccount := sub_accounts.SubAccountCreate{
+			Email:                 email,
+			AccountName:           "test_before_update",
+			MaxDailyGB:            1,
+			RetentionDays:         1,
+			Searchable:            false,
+			Accessible:            true,
+			DocSizeSetting:        false,
+			SharingObjectAccounts: []int32{},
+		}
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			defer underTest.DeleteSubAccount(subAccount.Id)
+			assert.Equal(t, "test_before_update", subAccount.AccountName)
+			subAccount.AccountName = "test_after_update"
+			time.Sleep(4 * time.Second)
+			err := underTest.UpdateSubAccount(subAccount.Id, *subAccount)
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -10,6 +10,7 @@ const ENV_LOGZIO_BASE_URL = "LOGZIO_BASE_URL"
 const ENV_LOGZIO_API_TOKEN string = "LOGZIO_API_TOKEN"
 const ENV_LOGZIO_ACCOUNT_ID string = "LOGZIO_ACCOUNT_ID"
 const LOGZIO_BASE_URL string = "https://api.logz.io"
+const ENV_LOGZIO_EMAIL string = "LOGZIO_EMAIL"
 
 func GetApiToken() (string, error) {
 	api_token := os.Getenv(ENV_LOGZIO_API_TOKEN)
@@ -33,4 +34,12 @@ func GetLogzIoBaseUrl() string {
 		return os.Getenv(ENV_LOGZIO_BASE_URL)
 	}
 	return LOGZIO_BASE_URL
+}
+
+func GetLogzioEmail() (string, error) {
+	email := os.Getenv(ENV_LOGZIO_EMAIL)
+	if len(email) > 0 {
+		return email, nil
+	}
+	return "", fmt.Errorf("%s env var not specified", ENV_LOGZIO_EMAIL)
 }


### PR DESCRIPTION
*Sub account:*
* Added integration tests.
* Allow empty array of `sharing account` - this is not a requirement when creating a sub-account via the UI or API, and is forcing users to share objects.

*Endpoints:*
* Fix bug for `custom endpoint` - as pointed in #76 , some endpoints don't require headers.