### PR TITLE
add resource name to not found message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ The library currently supports the following API endpoints:
 `go test -v -race ./...`
 
 ### Changelog
-
+- v1.9.1
+    - Bug fix - adjust "not found" message to all resources.
 - v1.9.0
     - Add [Archive logs API](https://docs.logz.io/api/#tag/Archive-logs).
     - Add [Restore logs API](https://docs.logz.io/api/#tag/Restore-logs).
+<details>
+  <summary markdown="span">Exapnd to check old versions </summary>
 - v1.8.0
     - `sub_accounts`:
         - Add `flexible` & `reservedDailyGB`.
@@ -35,8 +38,6 @@ The library currently supports the following API endpoints:
     - `endpoints`:
         - **Breaking changes:** refactor resource.
         - Add new endpoint types (OpsGenie, ServiceNow, Microsoft Teams).
-<details>
-  <summary markdown="span">Exapnd to check old versions </summary>
 - v1.7.0
     - Add [drop filters API](https://docs.logz.io/api/#tag/Drop-filters).
 - v1.6.0

--- a/alerts_v2/client_alerts_v2.go
+++ b/alerts_v2/client_alerts_v2.go
@@ -48,6 +48,8 @@ const (
 	getAlertOperation     = "GetAlertV2"
 	listAlertOperation    = "ListAlertsV2"
 	updateAlertOperation  = "UpdateAlertV2"
+
+	alertResourceName = "alert"
 )
 
 type AlertsV2Client struct {

--- a/alerts_v2/client_alerts_v2_create.go
+++ b/alerts_v2/client_alerts_v2_create.go
@@ -46,6 +46,7 @@ func (c *AlertsV2Client) CreateAlert(alert CreateAlertType) (*AlertType, error) 
 		NotFoundCode: createAlertServiceStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    createAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/alerts_v2/client_alerts_v2_delete.go
+++ b/alerts_v2/client_alerts_v2_delete.go
@@ -24,6 +24,7 @@ func (c *AlertsV2Client) DeleteAlert(alertId int64) error {
 		NotFoundCode: deleteAlertMethodNotFound,
 		ResourceId:   alertId,
 		ApiAction:    deleteAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	return err

--- a/alerts_v2/client_alerts_v2_disable.go
+++ b/alerts_v2/client_alerts_v2_disable.go
@@ -24,6 +24,7 @@ func (c *AlertsV2Client) DisableAlert(alert AlertType) (*AlertType, error) {
 		NotFoundCode: disableAlertServiceStatusNotFound,
 		ResourceId:   alert.AlertId,
 		ApiAction:    disableAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/alerts_v2/client_alerts_v2_enable.go
+++ b/alerts_v2/client_alerts_v2_enable.go
@@ -24,6 +24,7 @@ func (c *AlertsV2Client) EnableAlert(alert AlertType) (*AlertType, error) {
 		NotFoundCode: enableAlertMethodNotFound,
 		ResourceId:   alert.AlertId,
 		ApiAction:    enableAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/alerts_v2/client_alerts_v2_get.go
+++ b/alerts_v2/client_alerts_v2_get.go
@@ -25,6 +25,7 @@ func (c *AlertsV2Client) GetAlert(alertId int64) (*AlertType, error) {
 		NotFoundCode: getAlertMethodNotFound,
 		ResourceId:   alertId,
 		ApiAction:    getAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/alerts_v2/client_alerts_v2_list.go
+++ b/alerts_v2/client_alerts_v2_list.go
@@ -25,6 +25,7 @@ func (c *AlertsV2Client) ListAlerts() ([]AlertType, error) {
 		NotFoundCode: http.StatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    listAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/alerts_v2/client_alerts_v2_update.go
+++ b/alerts_v2/client_alerts_v2_update.go
@@ -36,6 +36,7 @@ func (c *AlertsV2Client) UpdateAlert(alertId int64, alert CreateAlertType) (*Ale
 		NotFoundCode: updateAlertMethodNotFound,
 		ResourceId:   alert,
 		ApiAction:    updateAlertOperation,
+		ResourceName: alertResourceName,
 	})
 
 	if err != nil {

--- a/archive_logs/client_archive_logs.go
+++ b/archive_logs/client_archive_logs.go
@@ -19,6 +19,8 @@ const (
 	deleteArchiveSettings   = "DeleteArchiveSettings"
 	testArchiveSettings     = "TestArchiveSettings"
 	listArchivesSettings    = "ListArchiveSettings"
+
+	archiveResourceName = "archive"
 )
 
 type ArchiveLogsClient struct {

--- a/archive_logs/client_archive_logs_delete.go
+++ b/archive_logs/client_archive_logs_delete.go
@@ -24,6 +24,7 @@ func (c *ArchiveLogsClient) DeleteArchiveLogs(archiveId int32) error {
 		NotFoundCode: deleteArchiveLogsStatusNotFound,
 		ResourceId:   archiveId,
 		ApiAction:    deleteArchiveSettings,
+		ResourceName: archiveResourceName,
 	})
 
 	return err

--- a/archive_logs/client_archive_logs_list.go
+++ b/archive_logs/client_archive_logs_list.go
@@ -25,6 +25,7 @@ func (c *ArchiveLogsClient) ListArchiveLog() ([]ArchiveLogs, error) {
 		NotFoundCode: http.StatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    listArchivesSettings,
+		ResourceName: archiveResourceName,
 	})
 
 	if err != nil {

--- a/archive_logs/client_archive_logs_retrieve.go
+++ b/archive_logs/client_archive_logs_retrieve.go
@@ -25,6 +25,7 @@ func (c *ArchiveLogsClient) RetrieveArchiveLogsSetting(archiveId int32) (*Archiv
 		NotFoundCode: retrieveArchiveLogsMethodNotFound,
 		ResourceId:   archiveId,
 		ApiAction:    retrieveArchiveSettings,
+		ResourceName: archiveResourceName,
 	})
 
 	if err != nil {

--- a/archive_logs/client_archive_logs_setup.go
+++ b/archive_logs/client_archive_logs_setup.go
@@ -36,6 +36,7 @@ func (c *ArchiveLogsClient) SetupArchive(createArchive CreateOrUpdateArchiving) 
 		NotFoundCode: http.StatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    setupArchiveApi,
+		ResourceName: archiveResourceName,
 	})
 
 	if err != nil {

--- a/archive_logs/client_archive_logs_update.go
+++ b/archive_logs/client_archive_logs_update.go
@@ -36,6 +36,7 @@ func (c *ArchiveLogsClient) UpdateArchiveLogs(archiveId int32, updateArchive Cre
 		NotFoundCode: updateArchiveLogsServiceNotFound,
 		ResourceId:   archiveId,
 		ApiAction:    updateArchiveSettings,
+		ResourceName: archiveResourceName,
 	})
 
 	if err != nil {

--- a/drop_filters/client_drop_filters.go
+++ b/drop_filters/client_drop_filters.go
@@ -12,6 +12,8 @@ const (
 	deactivateDropFilterOperation        = "DeactivateDropFilter"
 	deleteDropFilterOperation            = "DeleteDropFilter"
 	retrieveDropFiltersOperation         = "RetrieveDropFilters"
+
+	dropFilterResourceName = "drop filter"
 )
 
 type DropFiltersClient struct {

--- a/drop_filters/client_drop_filters_activate.go
+++ b/drop_filters/client_drop_filters_activate.go
@@ -23,6 +23,7 @@ func (c *DropFiltersClient) ActivateDropFilter(dropFilterId string) (*DropFilter
 		NotFoundCode: activateDropFilterMethodNotFound,
 		ResourceId:   dropFilterId,
 		ApiAction:    activateDropFilterOperation,
+		ResourceName: dropFilterResourceName,
 	})
 
 	if err != nil {

--- a/drop_filters/client_drop_filters_create.go
+++ b/drop_filters/client_drop_filters_create.go
@@ -46,6 +46,7 @@ func (c *DropFiltersClient) CreateDropFilter(createDropFilter CreateDropFilter) 
 		NotFoundCode: createDropFilterStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    createDropFilterOperation,
+		ResourceName: dropFilterResourceName,
 	})
 
 	if err != nil {

--- a/drop_filters/client_drop_filters_deactivate.go
+++ b/drop_filters/client_drop_filters_deactivate.go
@@ -23,6 +23,7 @@ func (c *DropFiltersClient) DeactivateDropFilter(dropFilterId string) (*DropFilt
 		NotFoundCode: deactivateDropFilterMethodNotFound,
 		ResourceId:   dropFilterId,
 		ApiAction:    deactivateDropFilterOperation,
+		ResourceName: dropFilterResourceName,
 	})
 
 	if err != nil {

--- a/drop_filters/client_drop_filters_delete.go
+++ b/drop_filters/client_drop_filters_delete.go
@@ -24,6 +24,7 @@ func (c *DropFiltersClient) DeleteDropFilter(dropFilterId string) error {
 		NotFoundCode: deleteDropFilterMethodNotFound,
 		ResourceId:   dropFilterId,
 		ApiAction:    deleteDropFilterOperation,
+		ResourceName: dropFilterResourceName,
 	})
 
 	return err

--- a/drop_filters/client_drop_filters_retrieve.go
+++ b/drop_filters/client_drop_filters_retrieve.go
@@ -26,6 +26,7 @@ func (c *DropFiltersClient) RetrieveDropFilters() ([]DropFilter, error) {
 		NotFoundCode: retrieveDropFilterStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    retrieveDropFiltersOperation,
+		ResourceName: dropFilterResourceName,
 	})
 
 	if err != nil {

--- a/endpoints/client_endpoints.go
+++ b/endpoints/client_endpoints.go
@@ -13,6 +13,8 @@ const (
 	listEndpointMethod      = "ListEndpoint"
 	updateEndpointMethod    = "UpdateEndpoint"
 	createEndpointMethod    = "CreateEndpoint"
+
+	endpointResourceName = "endpoint"
 )
 
 // supported endpoint types

--- a/endpoints/client_endpoints_create.go
+++ b/endpoints/client_endpoints_create.go
@@ -37,6 +37,7 @@ func (c *EndpointsClient) CreateEndpoint(endpoint CreateOrUpdateEndpoint) (*Crea
 		NotFoundCode: createEndpointStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    createEndpointMethod,
+		ResourceName: endpointResourceName,
 	})
 
 	if err != nil {

--- a/endpoints/client_endpoints_delete.go
+++ b/endpoints/client_endpoints_delete.go
@@ -25,6 +25,7 @@ func (c *EndpointsClient) DeleteEndpoint(endpointId int64) error {
 		NotFoundCode: deleteEndpointMethodNotFound,
 		ResourceId:   endpointId,
 		ApiAction:    deleteEndpointMethod,
+		ResourceName: endpointResourceName,
 	})
 
 	return err

--- a/endpoints/client_endpoints_get.go
+++ b/endpoints/client_endpoints_get.go
@@ -25,6 +25,7 @@ func (c *EndpointsClient) GetEndpoint(endpointId int64) (*Endpoint, error) {
 		NotFoundCode: getEndpointsMethodNotFound,
 		ResourceId:   endpointId,
 		ApiAction:    getEndpointMethod,
+		ResourceName: endpointResourceName,
 	})
 
 	if err != nil {

--- a/endpoints/client_endpoints_list.go
+++ b/endpoints/client_endpoints_list.go
@@ -26,6 +26,7 @@ func (c *EndpointsClient) ListEndpoints() ([]Endpoint, error) {
 		NotFoundCode: listEndpointsStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    listEndpointMethod,
+		ResourceName: endpointResourceName,
 	})
 
 	if err != nil {

--- a/endpoints/client_endpoints_update.go
+++ b/endpoints/client_endpoints_update.go
@@ -36,6 +36,7 @@ func (c *EndpointsClient) UpdateEndpoint(id int64, endpoint CreateOrUpdateEndpoi
 		NotFoundCode: updateEndpointMethodNotFound,
 		ResourceId:   id,
 		ApiAction:    updateEndpointMethod,
+		ResourceName: endpointResourceName,
 	})
 
 	if err != nil {

--- a/log_shipping_tokens/client_log_shipping_tokens.go
+++ b/log_shipping_tokens/client_log_shipping_tokens.go
@@ -19,6 +19,8 @@ const (
 
 	retrieveSortFieldCreatedAtValue = "createdAt"
 	retrieveSortFieldNameValue      = "name"
+
+	logShippingTokenResourceName = "log shipping token"
 )
 
 type LogShippingTokensClient struct {

--- a/log_shipping_tokens/client_log_shipping_tokens_create.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_create.go
@@ -46,6 +46,7 @@ func (c *LogShippingTokensClient) CreateLogShippingToken(token CreateLogShipping
 		NotFoundCode: createLogShippingTokenStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationCreateLogShippingToken,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	if err != nil {

--- a/log_shipping_tokens/client_log_shipping_tokens_delete.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_delete.go
@@ -24,6 +24,7 @@ func (c *LogShippingTokensClient) DeleteLogShippingToken(tokenId int32) error {
 		NotFoundCode: deleteLogShippingTokenMethodNotFound,
 		ResourceId:   tokenId,
 		ApiAction:    operationDeleteLogShippingToken,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	return err

--- a/log_shipping_tokens/client_log_shipping_tokens_get.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_get.go
@@ -26,6 +26,7 @@ func (c *LogShippingTokensClient) GetLogShippingToken(tokenId int32) (*LogShippi
 		NotFoundCode: getLogShippingTokenMethodNotFound,
 		ResourceId:   tokenId,
 		ApiAction:    operationGetLogShippingToken,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	if err != nil {

--- a/log_shipping_tokens/client_log_shipping_tokens_get_available_num.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_get_available_num.go
@@ -27,6 +27,7 @@ func (c *LogShippingTokensClient) GetLogShippingLimitsToken() (*LogShippingToken
 		NotFoundCode: getAvailableLogShippingTokensNumberStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationGetLogShippingTokensLimits,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	if err != nil {

--- a/log_shipping_tokens/client_log_shipping_tokens_retrieve.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_retrieve.go
@@ -35,6 +35,7 @@ func (c *LogShippingTokensClient) RetrieveLogShippingTokens(retrieveRequest Retr
 		NotFoundCode: retrieveLogShippingTokenStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationRetrieveLogShippingTokens,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	if err != nil {

--- a/log_shipping_tokens/client_log_shipping_tokens_update.go
+++ b/log_shipping_tokens/client_log_shipping_tokens_update.go
@@ -36,6 +36,7 @@ func (c *LogShippingTokensClient) UpdateLogShippingToken(tokenId int32, token Up
 		NotFoundCode: updateLogShippingTokenMethodNotFound,
 		ResourceId:   tokenId,
 		ApiAction:    operationUpdateLogShippingToken,
+		ResourceName: logShippingTokenResourceName,
 	})
 
 	if err != nil {

--- a/restore_logs/client_restore_logs.go
+++ b/restore_logs/client_restore_logs.go
@@ -20,6 +20,8 @@ const (
 	getRestoreOperation      = "GetRestoreOperation"
 	deleteRestoreOperation   = "DeleteRestoreOperation"
 	initiateRestoreOperation = "InitiateRestoreOperation"
+
+	restoreResourceName = "restore"
 )
 
 type RestoreClient struct {

--- a/restore_logs/client_restore_logs_delete.go
+++ b/restore_logs/client_restore_logs_delete.go
@@ -16,24 +16,6 @@ const (
 
 // DeleteRestoreOperation aborts a restore process before its completion
 func (c *RestoreClient) DeleteRestoreOperation(restoreId int32) (*RestoreOperation, error) {
-	//req, err := c.buildDeleteApiRequest(c.ApiToken, restoreId)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//httpClient := client.GetHttpClient(req)
-	//resp, err := httpClient.Do(req)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//jsonBytes, _ := ioutil.ReadAll(resp.Body)
-	//if !logzio_client.CheckValidStatus(resp, []int{deleteRestoreLogsServiceSuccess}) {
-	//	if resp.StatusCode == deleteRestoreLogsMethodNotFound {
-	//		return nil, fmt.Errorf("API call %s failed with missing restore operation %d, data: %s", deleteRestoreOperation, restoreId, jsonBytes)
-	//	}
-	//
-	//	return nil, fmt.Errorf("API call %s failed with status code %d, data: %s", deleteRestoreOperation, resp.StatusCode, jsonBytes)
-	//}
 	res, err := logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
 		ApiToken:     c.ApiToken,
 		HttpMethod:   deleteRestoreLogsServiceMethod,
@@ -43,6 +25,7 @@ func (c *RestoreClient) DeleteRestoreOperation(restoreId int32) (*RestoreOperati
 		NotFoundCode: deleteRestoreLogsMethodNotFound,
 		ResourceId:   restoreId,
 		ApiAction:    deleteRestoreOperation,
+		ResourceName: restoreResourceName,
 	})
 
 	var restoreOperation RestoreOperation
@@ -53,14 +36,3 @@ func (c *RestoreClient) DeleteRestoreOperation(restoreId int32) (*RestoreOperati
 
 	return &restoreOperation, nil
 }
-
-//func (c *RestoreClient) buildDeleteApiRequest(apiToken string, restoreId int32) (*http.Request, error) {
-//	baseUrl := c.BaseUrl
-//	req, err := http.NewRequest(deleteRestoreLogsServiceMethod, fmt.Sprintf(deleteRestoreLogsLogsServiceUrl, baseUrl, restoreId), nil)
-//	if err != nil {
-//		return nil, err
-//	}
-//	logzio_client.AddHttpHeaders(apiToken, req)
-//
-//	return req, err
-//}

--- a/restore_logs/client_restore_logs_get.go
+++ b/restore_logs/client_restore_logs_get.go
@@ -25,6 +25,7 @@ func (c *RestoreClient) GetRestoreOperation(restoreId int32) (*RestoreOperation,
 		NotFoundCode: getRestoreLogsLogsMethodNotFound,
 		ResourceId:   restoreId,
 		ApiAction:    getRestoreOperation,
+		ResourceName: restoreResourceName,
 	})
 
 	if err != nil {

--- a/restore_logs/client_restore_logs_initiate.go
+++ b/restore_logs/client_restore_logs_initiate.go
@@ -34,6 +34,7 @@ func (c *RestoreClient) InitiateRestoreOperation(initiateRestore InitiateRestore
 		NotFoundCode: http.StatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    initiateRestoreOperation,
+		ResourceName: restoreResourceName,
 	})
 
 	if err != nil {

--- a/restore_logs/client_restore_logs_list.go
+++ b/restore_logs/client_restore_logs_list.go
@@ -25,6 +25,7 @@ func (c *RestoreClient) ListRestoreOperations() ([]RestoreOperation, error) {
 		NotFoundCode: http.StatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    listRestoreOperations,
+		ResourceName: restoreResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account.go
+++ b/sub_accounts/client_sub_account.go
@@ -16,6 +16,8 @@ const (
 	operationListDetailedSubAccounts = "ListDetailedSubAccounts"
 	operationUpdateSubAccount        = "UpdateSubAccount"
 	operationCreateSubAccount        = "CreateSubAccount"
+
+	subAccountResourceName = "sub account"
 )
 
 type SubAccountClient struct {

--- a/sub_accounts/client_sub_account_create.go
+++ b/sub_accounts/client_sub_account_create.go
@@ -45,6 +45,7 @@ func (c *SubAccountClient) CreateSubAccount(createSubAccount CreateOrUpdateSubAc
 		NotFoundCode: createSubAccountStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationCreateSubAccount,
+		ResourceName: subAccountResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account_delete.go
+++ b/sub_accounts/client_sub_account_delete.go
@@ -24,6 +24,7 @@ func (c *SubAccountClient) DeleteSubAccount(subAccountId int64) error {
 		NotFoundCode: deleteSubAccountMethodNotFound,
 		ResourceId:   subAccountId,
 		ApiAction:    operationDeleteSubAccount,
+		ResourceName: subAccountResourceName,
 	})
 
 	return err

--- a/sub_accounts/client_sub_account_get.go
+++ b/sub_accounts/client_sub_account_get.go
@@ -25,6 +25,7 @@ func (c *SubAccountClient) GetSubAccount(subAccountId int64) (*SubAccount, error
 		NotFoundCode: getSubAccountServiceNotFound,
 		ResourceId:   subAccountId,
 		ApiAction:    operationGetSubAccount,
+		ResourceName: subAccountResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account_get_detailed.go
+++ b/sub_accounts/client_sub_account_get_detailed.go
@@ -25,6 +25,7 @@ func (c *SubAccountClient) GetDetailedSubAccount(subAccountId int64) (*DetailedS
 		NotFoundCode: getDetailedSubAccountServiceNotFound,
 		ResourceId:   subAccountId,
 		ApiAction:    operationGetDetailedSubAccount,
+		ResourceName: subAccountResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account_list.go
+++ b/sub_accounts/client_sub_account_list.go
@@ -26,6 +26,7 @@ func (c *SubAccountClient) ListSubAccounts() ([]SubAccount, error) {
 		NotFoundCode: listSubAccountStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationListSubAccounts,
+		ResourceName: subAccountResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account_list_detailed.go
+++ b/sub_accounts/client_sub_account_list_detailed.go
@@ -26,6 +26,7 @@ func (c *SubAccountClient) ListDetailedSubAccounts() ([]DetailedSubAccount, erro
 		NotFoundCode: listDetailedSubAccountStatusNotFound,
 		ResourceId:   nil,
 		ApiAction:    operationListSubAccounts,
+		ResourceName: subAccountResourceName,
 	})
 
 	if err != nil {

--- a/sub_accounts/client_sub_account_update.go
+++ b/sub_accounts/client_sub_account_update.go
@@ -35,6 +35,7 @@ func (c *SubAccountClient) UpdateSubAccount(subAccountId int64, updateSubAccount
 		NotFoundCode: updateSubAccountServiceNotFound,
 		ResourceId:   subAccountId,
 		ApiAction:    operationUpdateSubAccount,
+		ResourceName: subAccountResourceName,
 	})
 
 	return err

--- a/utils.go
+++ b/utils.go
@@ -24,6 +24,7 @@ type LogzioApiCallDetails struct {
 	NotFoundCode int
 	ResourceId   interface{}
 	ApiAction    string
+	ResourceName string
 }
 
 func AddHttpHeaders(apiToken string, req *http.Request) {
@@ -97,8 +98,8 @@ func CallLogzioApi(logzioCall LogzioApiCallDetails) ([]byte, error) {
 	jsonBytes, _ := ioutil.ReadAll(resp.Body)
 	if !CheckValidStatus(resp, logzioCall.SuccessCodes) {
 		if resp.StatusCode == logzioCall.NotFoundCode {
-			return nil, fmt.Errorf("API call %s failed with missing archive %d, data: %s",
-				logzioCall.ApiAction, logzioCall.ResourceId, jsonBytes)
+			return nil, fmt.Errorf("API call %s failed with missing %s %d, data: %s",
+				logzioCall.ApiAction, logzioCall.ResourceName, logzioCall.ResourceId, jsonBytes)
 		}
 
 		return nil, fmt.Errorf("API call %s failed with status code %d, data: %s",


### PR DESCRIPTION
Fix not found message, to match all resources.
I've added to the `LogzioApiCallDetails` struct a new field - `ResourceName`.
Now, when using func `CallLogzioApi`, it will use the ResourceName in the message.