### PR TITLE
1.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,17 @@ The library currently supports the following API endpoints:
 `go test -v -race ./...`
 
 ### Changelog
+
+- v1.10.1
+  - Bug fix - **custom endpoint**: allow empty string for Headers field. 
 - v1.10.0
     - Add [Authentication groups API](https://docs.logz.io/api/#tag/Authentication-groups).
     - Add tests to retrieve archive.
     - Improve tests.
-- v1.9.1
-    - Bug fix - adjust "not found" message to all resources.
 <details>
   <summary markdown="span">Exapnd to check old versions </summary>
+- v1.9.1
+    - Bug fix - adjust "not found" message to all resources.
 - v1.9.0
     - Add [Archive logs API](https://docs.logz.io/api/#tag/Archive-logs).
     - Add [Restore logs API](https://docs.logz.io/api/#tag/Restore-logs).

--- a/endpoints/client_endpoints.go
+++ b/endpoints/client_endpoints.go
@@ -35,7 +35,7 @@ type CreateOrUpdateEndpoint struct {
 	Description   string      `json:"description"`             // all
 	Url           string      `json:"url,omitempty"`           // slack, custom, serviceNow, microsoftTeams
 	Method        string      `json:"method,omitempty'"`       // custom
-	Headers       string      `json:"headers,omitempty"`       // custom
+	Headers       *string     `json:"headers,omitempty"`       // custom. Set to pointer to allow an empty string
 	BodyTemplate  interface{} `json:"bodyTemplate,omitempty"`  // custom
 	ServiceKey    string      `json:"serviceKey,omitempty"`    // pagerDuty
 	ApiToken      string      `json:"apiToken,omitempty"`      // bigPanda

--- a/endpoints/create_endpoint_integration_test.go
+++ b/endpoints/create_endpoint_integration_test.go
@@ -14,7 +14,8 @@ func TestIntegrationEndpoints_CreateEndpointNoType(t *testing.T) {
 		createEndpoint.Title = createEndpoint.Title + "_create_no_type"
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.Error(t, err)
@@ -29,7 +30,8 @@ func TestIntegrationEndpoints_CreateEndpointCaseInsensitivity(t *testing.T) {
 		createEndpoint.Title = createEndpoint.Title + "_create_case_insensitive"
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.Type = "Custom"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)

--- a/endpoints/endpoints_custom_integration_test.go
+++ b/endpoints/endpoints_custom_integration_test.go
@@ -17,7 +17,8 @@ func TestIntegrationEndpoints_CreateEndpointCustom(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {
@@ -35,7 +36,6 @@ func TestIntegrationEndpoints_CreateEndpointCustomEmptyHeaders(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = ""
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {
@@ -52,7 +52,8 @@ func TestIntegrationEndpoints_CreateEndpointCustomEmptyBodyTemplate(t *testing.T
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = nil
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {
@@ -68,7 +69,8 @@ func TestIntegrationEndpoints_CreateEndpointCustomNoUrl(t *testing.T) {
 		createEndpoint.Title = createEndpoint.Title + "_create_custom_no_url"
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.Error(t, err)
@@ -83,7 +85,8 @@ func TestIntegrationEndpoints_CreateEndpointCustomNoMethod(t *testing.T) {
 		createEndpoint.Title = createEndpoint.Title + "_create_custom_no_method"
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.Error(t, err)
@@ -99,7 +102,8 @@ func TestIntegrationEndpoints_CreateEndpointCustomDuplicationError(t *testing.T)
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {
@@ -120,7 +124,8 @@ func TestIntegrationEndpoints_CreateEndpointNoTitle(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.Error(t, err)
@@ -136,7 +141,8 @@ func TestIntegrationEndpoints_UpdateEndpointCustom(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {
@@ -146,10 +152,20 @@ func TestIntegrationEndpoints_UpdateEndpointCustom(t *testing.T) {
 			createEndpoint.Description = "This is an UPDATED description"
 			createEndpoint.Method = http.MethodPut
 			createEndpoint.Url = testsUrlUpdate
+			*createEndpoint.Headers = ""
 			updated, err := underTest.UpdateEndpoint(int64(endpoint.Id), createEndpoint)
 			assert.NoError(t, err)
 			assert.NotNil(t, updated)
 			assert.Equal(t, endpoint.Id, updated.Id)
+			time.Sleep(2 * time.Second)
+			updatedGet, err := underTest.GetEndpoint(int64(updated.Id))
+			assert.NoError(t, err)
+			assert.NotNil(t, updatedGet)
+			assert.Equal(t, createEndpoint.Title, updatedGet.Title)
+			assert.Equal(t, createEndpoint.Description, updatedGet.Description)
+			assert.Equal(t, createEndpoint.Method, updatedGet.Method)
+			assert.Equal(t, createEndpoint.Url, updatedGet.Url)
+			assert.Equal(t, *createEndpoint.Headers, updatedGet.Headers)
 		}
 	}
 }
@@ -162,7 +178,8 @@ func TestIntegrationEndpoints_GetEndpointCustom(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		if assert.NoError(t, err) && assert.NotNil(t, endpoint) {

--- a/endpoints/endpoints_custom_integration_test.go
+++ b/endpoints/endpoints_custom_integration_test.go
@@ -193,7 +193,7 @@ func TestIntegrationEndpoints_GetEndpointCustom(t *testing.T) {
 			assert.Equal(t, strings.ToLower(createEndpoint.Type), strings.ToLower(endpointFromGet.Type))
 			assert.Equal(t, createEndpoint.Url, endpointFromGet.Url)
 			assert.Equal(t, createEndpoint.Method, endpointFromGet.Method)
-			assert.Equal(t, createEndpoint.Headers, endpointFromGet.Headers)
+			assert.Equal(t, *createEndpoint.Headers, endpointFromGet.Headers)
 			assert.NotEmpty(t, endpointFromGet.BodyTemplate)
 		}
 	}

--- a/endpoints/endpoints_custom_test.go
+++ b/endpoints/endpoints_custom_test.go
@@ -35,7 +35,8 @@ func TestEndpoints_CreateCustomEndpoint(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.NoError(t, err)
@@ -66,7 +67,8 @@ func TestEndpoints_CreateCustomEndpointApiFail(t *testing.T) {
 		createEndpoint.Type = endpoints.EndpointTypeCustom
 		createEndpoint.Url = testsUrl
 		createEndpoint.Method = http.MethodPost
-		createEndpoint.Headers = "hello=there,header=two"
+		createEndpoint.Headers = new(string)
+		*createEndpoint.Headers = "hello=there,header=two"
 		createEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.CreateEndpoint(createEndpoint)
 		assert.Error(t, err)
@@ -99,7 +101,8 @@ func TestEndpoints_UpdateCustomEndpoint(t *testing.T) {
 		updateEndpoint.Type = endpoints.EndpointTypeCustom
 		updateEndpoint.Url = testsUrl
 		updateEndpoint.Method = http.MethodPost
-		updateEndpoint.Headers = "hello=there,header=two"
+		updateEndpoint.Headers = new(string)
+		*updateEndpoint.Headers = "hello=there,header=two"
 		updateEndpoint.BodyTemplate = map[string]string{"hello": "there", "header": "two"}
 		endpoint, err := underTest.UpdateEndpoint(endpointId, updateEndpoint)
 		assert.NoError(t, err)


### PR DESCRIPTION
### Bug fix for custom endpoint:
Currently when creating a request to create/update an endpoint, if you'll pass an empty string, it will be omitted from the request.
This creates a bug when trying to update the header from a certain string to an empty string (`""`) - the field is omitted and then not updated.
This PR changes the field to type `*string` to avoid this issue, so when passing an empty string, it won't be omitted.