### PR TITLE
update restore + upgrade to Go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,13 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       GO111MODULE: on
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.18
     - name: Before install
       run: |
         go get golang.org/x/tools/cmd/cover

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ The library currently supports the following API endpoints:
 
 ### Changelog
 
-- v1.12.0 [WIP]
+- v1.12.0
+  - Upgrade to Go 1.18.
   - Refactor `users`, adjust to the recent API fields.
+  - Add field `UserName` to `restore` initiate request, to match recent API fields.
 - v1.11.0
   - Add [Kibana Objects](https://docs.logz.io/api/#tag/Import-or-export-Kibana-objects).
 - v1.10.3

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,17 @@
 module github.com/logzio/logzio_terraform_client
 
-go 1.16
+go 1.18
 
 require (
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/stretchr/testify v1.3.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20191008105621-543471e840be // indirect
 )

--- a/restore_logs/client_restore_logs.go
+++ b/restore_logs/client_restore_logs.go
@@ -30,6 +30,7 @@ type RestoreClient struct {
 
 type InitiateRestore struct {
 	AccountName string `json:"accountName"` // Name of the restored account
+	UserName    string `json:"username"`
 	StartTime   int64  `json:"startTime"`
 	EndTime     int64  `json:"endTime"`
 }

--- a/restore_logs/client_restore_logs_initiate.go
+++ b/restore_logs/client_restore_logs_initiate.go
@@ -63,5 +63,9 @@ func validateInitiateRestoreOperation(initiateRestore InitiateRestore) error {
 		return fmt.Errorf("EndTime must be set")
 	}
 
+	if len(initiateRestore.UserName) == 0 {
+		return fmt.Errorf("UserName must be set")
+	}
+
 	return nil
 }

--- a/restore_logs/restore_logs_initiate_test.go
+++ b/restore_logs/restore_logs_initiate_test.go
@@ -23,6 +23,7 @@ func TestRestoreLogs_InitiateRestore(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, target)
 			assert.NotEmpty(t, target.AccountName)
+			assert.NotEmpty(t, target.UserName)
 			assert.NotZero(t, target.StartTime)
 			assert.NotZero(t, target.EndTime)
 			w.Header().Set("Content-Type", "application/json")

--- a/restore_logs/restore_logs_test.go
+++ b/restore_logs/restore_logs_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"time"
 )
 
@@ -83,6 +84,7 @@ func getInitiateRestoreOperationIntegrationTest() restore_logs.InitiateRestore {
 	hourAgo := currentTime.Add(-time.Hour)
 	return restore_logs.InitiateRestore{
 		AccountName: fmt.Sprintf("test-account-%s", currentTime.Format("2006-01-02,15:04:05")),
+		UserName:    os.Getenv(test_utils.EnvLogzioEmail),
 		StartTime:   hourAgo.Unix(),
 		EndTime:     currentTime.Unix(),
 	}
@@ -91,6 +93,7 @@ func getInitiateRestoreOperationIntegrationTest() restore_logs.InitiateRestore {
 func getInitiateRestoreOperationTest() restore_logs.InitiateRestore {
 	return restore_logs.InitiateRestore{
 		AccountName: "test_account",
+		UserName:    "test@test.com",
 		StartTime:   1634437185,
 		EndTime:     1634444385,
 	}


### PR DESCRIPTION
In this PR:
- Upgrade to Go 1.18.
- Update restore logs to match current API (added to initiate request the field `username`).
- Update test workflow:
  - Upgrade ubuntu version as the current one is deprecated.
  - Upgrade go to 1.18 to match the version of the repo.