### PR TITLE
Alerts schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,21 @@ The library currently supports the following API endpoints:
 
 ### Changelog
 
+- v1.14.0
+  - `alerts_v2` - support new field `schedule`
 - v1.13.1
   - Add retry mechanism for requests.
 - v1.13.0
   - Bug fix - **sub_accounts**: field `ReservedDailyGB` in requests can be 0.
-- v1.12.0
-  - Upgrade to Go 1.18.
-  - Refactor `users`, adjust to the recent API fields.
-  - Add field `UserName` to `restore` initiate request, to match recent API fields.
 
 
 <details>
   <summary markdown="span">Exapnd to check old versions </summary>
+
+- v1.12.0
+  - Upgrade to Go 1.18.
+  - Refactor `users`, adjust to the recent API fields.
+  - Add field `UserName` to `restore` initiate request, to match recent API fields.
 - v1.11.0
   - Add [Kibana Objects](https://docs.logz.io/api/#tag/Import-or-export-Kibana-objects).
 - v1.10.3

--- a/alerts_v2/client_alerts_v2.go
+++ b/alerts_v2/client_alerts_v2.go
@@ -134,11 +134,6 @@ type ScheduleObj struct {
 	Timezone       string `json:"timezone,omitempty"`
 }
 
-//type ScheduleObj struct {
-//	Cron     string `json:"cron,omitempty"`
-//	Timezone string `json:"timezone,omitempty"`
-//}
-
 type AlertType struct {
 	AlertId                int64               `json:"id"`
 	UpdatedAt              string              `json:"updatedAt"`

--- a/alerts_v2/client_alerts_v2.go
+++ b/alerts_v2/client_alerts_v2.go
@@ -65,6 +65,7 @@ type CreateAlertType struct {
 	SubComponents          []SubAlert          `json:"subComponents,omitempty"`
 	Correlations           SubAlertCorrelation `json:"correlations,omitempty"`
 	Enabled                string              `json:"enabled,omitempty"`
+	Schedule               ScheduleObj         `json:"schedule,omitempty"`
 }
 
 type AlertOutput struct {
@@ -128,6 +129,16 @@ type SubAlertCorrelation struct {
 	Joins                []map[string]string `json:"joins,omitempty"`
 }
 
+type ScheduleObj struct {
+	CronExpression string `json:"cronExpression,omitempty"`
+	Timezone       string `json:"timezone,omitempty"`
+}
+
+//type ScheduleObj struct {
+//	Cron     string `json:"cron,omitempty"`
+//	Timezone string `json:"timezone,omitempty"`
+//}
+
 type AlertType struct {
 	AlertId                int64               `json:"id"`
 	UpdatedAt              string              `json:"updatedAt"`
@@ -142,6 +153,7 @@ type AlertType struct {
 	SearchTimeFrameMinutes int                 `json:"searchTimeFrameMinutes"`
 	SubComponents          []SubAlert          `json:"subComponents"`
 	Correlations           SubAlertCorrelation `json:"correlations,omitempty"`
+	Schedule               ScheduleObj         `json:"schedule,omitempty"`
 }
 
 func New(apiToken, baseUrl string) (*AlertsV2Client, error) {

--- a/alerts_v2/create_alerts_v2_integration_test.go
+++ b/alerts_v2/create_alerts_v2_integration_test.go
@@ -185,3 +185,21 @@ func TestIntegrationAlertsV2_CreateAlertOutputTypeTableSortAsc(t *testing.T) {
 		}
 	}
 }
+
+func TestIntegrationAlertsV2_CreateAlertWithSchedule(t *testing.T) {
+	underTest, err := setupAlertsV2IntegrationTest()
+
+	if assert.NoError(t, err) {
+		createAlert := getCreateAlertType()
+		createAlert.Title = "test alerts v2 with schedule"
+		createAlert.Schedule.CronExpression = "0 0/5 9-17 ? * * *"
+		createAlert.Schedule.Timezone = "Asia/Jerusalem"
+		alert, err := underTest.CreateAlert(createAlert)
+
+		time.Sleep(4 * time.Second)
+		if assert.NoError(t, err) && assert.NotNil(t, alert) {
+			assert.Equal(t, createAlert.Schedule.Timezone, alert.Schedule.Timezone)
+			defer underTest.DeleteAlert(alert.AlertId)
+		}
+	}
+}

--- a/alerts_v2/get_alerts_v2_integration_test.go
+++ b/alerts_v2/get_alerts_v2_integration_test.go
@@ -26,6 +26,29 @@ func TestIntegrationAlertsV2_GetAlert(t *testing.T) {
 	}
 }
 
+func TestIntegrationAlertsV2_GetAlertWithSchedule(t *testing.T) {
+	underTest, err := setupAlertsV2IntegrationTest()
+
+	if assert.NoError(t, err) {
+		createAlert := getCreateAlertType()
+		createAlert.Title = "test alerts v2 get with schedule"
+		createAlert.Schedule.CronExpression = "0 0/5 9-17 ? * * *"
+		createAlert.Schedule.Timezone = "America/Costa_Rica"
+
+		alert, err := underTest.CreateAlert(createAlert)
+		if assert.NoError(t, err) && assert.NotNil(t, alert) {
+			time.Sleep(4 * time.Second)
+			getAlert, err := underTest.GetAlert(alert.AlertId)
+			assert.NoError(t, err)
+			assert.NotNil(t, getAlert)
+			assert.Equal(t, alert.AlertId, getAlert.AlertId)
+			assert.Equal(t, createAlert.Schedule.Timezone, getAlert.Schedule.Timezone)
+
+			defer underTest.DeleteAlert(getAlert.AlertId)
+		}
+	}
+}
+
 func TestIntegrationAlertsV2_GetAlertIdNotExist(t *testing.T) {
 	underTest, err := setupAlertsV2IntegrationTest()
 

--- a/alerts_v2/update_alerts_v2_integration_test.go
+++ b/alerts_v2/update_alerts_v2_integration_test.go
@@ -28,3 +28,54 @@ func TestIntegrationAlertsV2_UpdateAlert(t *testing.T) {
 
 	}
 }
+
+func TestIntegrationAlertsV2_UpdateAlertAddSchedule(t *testing.T) {
+	underTest, err := setupAlertsV2IntegrationTest()
+
+	if assert.NoError(t, err) {
+		createAlert := getCreateAlertType()
+		createAlert.Title = "test alerts v2 update add schedule"
+
+		alert, err := underTest.CreateAlert(createAlert)
+		if assert.NoError(t, err) && assert.NotNil(t, alert) {
+			time.Sleep(4 * time.Second)
+			createAlert.Schedule.CronExpression = "0 0/5 9-17 ? * * *"
+			createAlert.Schedule.Timezone = "Europe/Madrid"
+			updated, err := underTest.UpdateAlert(alert.AlertId, createAlert)
+			assert.NoError(t, err)
+			assert.NotNil(t, updated)
+			assert.Equal(t, createAlert.Schedule.Timezone, updated.Schedule.Timezone)
+
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteAlert(updated.AlertId)
+		}
+
+	}
+}
+
+func TestIntegrationAlertsV2_UpdateAlertRemoveSchedule(t *testing.T) {
+	underTest, err := setupAlertsV2IntegrationTest()
+
+	if assert.NoError(t, err) {
+		createAlert := getCreateAlertType()
+		createAlert.Title = "test alerts v2 update remove schedule"
+		createAlert.Schedule.CronExpression = "0 0/5 9-17 ? * * *"
+		createAlert.Schedule.Timezone = "Europe/Madrid"
+
+		alert, err := underTest.CreateAlert(createAlert)
+		if assert.NoError(t, err) && assert.NotNil(t, alert) {
+			time.Sleep(4 * time.Second)
+			createAlert.Schedule.CronExpression = ""
+			createAlert.Schedule.Timezone = ""
+			updated, err := underTest.UpdateAlert(alert.AlertId, createAlert)
+			assert.NoError(t, err)
+			assert.NotNil(t, updated)
+			assert.Equal(t, createAlert.Schedule.CronExpression, updated.Schedule.CronExpression)
+			assert.Equal(t, "UTC", updated.Schedule.Timezone)
+
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteAlert(updated.AlertId)
+		}
+
+	}
+}

--- a/sub_accounts/sub_account_create_integration_test.go
+++ b/sub_accounts/sub_account_create_integration_test.go
@@ -12,7 +12,7 @@ func TestIntegrationSubAccount_CreateSubAccount(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_create"
 
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
@@ -32,7 +32,7 @@ func TestIntegrationSubAccount_CreateSubAccountWithSharingAccount(t *testing.T) 
 		accountId, err := test_utils.GetAccountId()
 		assert.NoError(t, err)
 
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_create_with_sharing_account"
 		createSubAccount.SharingObjectsAccounts = []int32{int32(accountId)}
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
@@ -49,7 +49,7 @@ func TestIntegrationSubAccount_CreateSubAccountWithUtilization(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_create_utilization"
 		createSubAccount.UtilizationSettings.UtilizationEnabled = strconv.FormatBool(true)
 		createSubAccount.UtilizationSettings.FrequencyMinutes = 5
@@ -74,7 +74,7 @@ this test will be tested locally by uncommenting it, and not as part of the auto
 //	underTest, email, err := setupSubAccountsIntegrationTest()
 //
 //	if assert.NoError(t, err) {
-//		createSubAccount := getCreatrOrUpdateSubAccount(email)
+//		createSubAccount := getCreateOrUpdateSubAccount(email)
 //		createSubAccount.AccountName = createSubAccount.AccountName + "_create_flexible"
 //		createSubAccount.Flexible = strconv.FormatBool(true)
 //		createSubAccount.ReservedDailyGB = new(float32)
@@ -94,7 +94,7 @@ this test will be tested locally by uncommenting it, and not as part of the auto
 //	underTest, email, err := setupSubAccountsIntegrationTest()
 //
 //	if assert.NoError(t, err) {
-//		createSubAccount := getCreatrOrUpdateSubAccount(email)
+//		createSubAccount := getCreateOrUpdateSubAccount(email)
 //		createSubAccount.AccountName = createSubAccount.AccountName + "_create_flexible"
 //		createSubAccount.Flexible = strconv.FormatBool(true)
 //		createSubAccount.ReservedDailyGB = new(float32)
@@ -114,7 +114,7 @@ func TestIntegrationSubAccount_CreateSubAccountInvalidMail(t *testing.T) {
 	underTest, _, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount("invalid@mail.test")
+		createSubAccount := getCreateOrUpdateSubAccount("invalid@mail.test")
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 
 		assert.Error(t, err)
@@ -126,7 +126,7 @@ func TestIntegrationSubAccount_CreateSubAccountNoMail(t *testing.T) {
 	underTest, _, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount("")
+		createSubAccount := getCreateOrUpdateSubAccount("")
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 
 		assert.Error(t, err)
@@ -138,7 +138,7 @@ func TestIntegrationSubAccount_CreateSubAccountNoAccountName(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = ""
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 
@@ -151,7 +151,7 @@ func TestIntegrationSubAccount_CreateSubAccountNoRetention(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_no_retention"
 		createSubAccount.RetentionDays = 0
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)

--- a/sub_accounts/sub_account_create_test.go
+++ b/sub_accounts/sub_account_create_test.go
@@ -28,7 +28,7 @@ func TestSubAccount_CreateValidSubAccount(t *testing.T) {
 			fmt.Fprint(w, fixture("create_subaccount.json"))
 		})
 
-		createSubAccount := getCreatrOrUpdateSubAccount("test.user@test.user")
+		createSubAccount := getCreateOrUpdateSubAccount("test.user@test.user")
 		createSubAccount.AccountName = createSubAccount.AccountName + "_test_create"
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 		assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestSubAccount_CreateValidSubAccountAPIFail(t *testing.T) {
 			fmt.Fprint(w, fixture("create_subaccount_failed.txt"))
 		})
 
-		createSubAccount := getCreatrOrUpdateSubAccount("test.user@test.user")
+		createSubAccount := getCreateOrUpdateSubAccount("test.user@test.user")
 		createSubAccount.AccountName = createSubAccount.AccountName + "_test_create"
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 		assert.Error(t, err)
@@ -61,7 +61,7 @@ func TestSubAccount_CreateSubAccountNoEmail(t *testing.T) {
 	underTest, err, teardown := setupSubAccountsTest()
 	defer teardown()
 
-	createSubAccount := getCreatrOrUpdateSubAccount("")
+	createSubAccount := getCreateOrUpdateSubAccount("")
 	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_email"
 	subAccount, err := underTest.CreateSubAccount(createSubAccount)
 	assert.Error(t, err)
@@ -72,7 +72,7 @@ func TestSubAccount_CreateSubAccountNoAccountName(t *testing.T) {
 	underTest, err, teardown := setupSubAccountsTest()
 	defer teardown()
 
-	createSubAccount := getCreatrOrUpdateSubAccount("test.user@test.user")
+	createSubAccount := getCreateOrUpdateSubAccount("test.user@test.user")
 	createSubAccount.AccountName = ""
 	subAccount, err := underTest.CreateSubAccount(createSubAccount)
 	assert.Error(t, err)
@@ -83,7 +83,7 @@ func TestSubAccount_CreateSubAccountNoRetentionDays(t *testing.T) {
 	underTest, err, teardown := setupSubAccountsTest()
 	defer teardown()
 
-	createSubAccount := getCreatrOrUpdateSubAccount("test.user@test.user")
+	createSubAccount := getCreateOrUpdateSubAccount("test.user@test.user")
 	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_retention"
 	createSubAccount.RetentionDays = 0
 	subAccount, err := underTest.CreateSubAccount(createSubAccount)
@@ -95,7 +95,7 @@ func TestSubAccount_CreateSubAccountNoSharingAccount(t *testing.T) {
 	underTest, err, teardown := setupSubAccountsTest()
 	defer teardown()
 
-	createSubAccount := getCreatrOrUpdateSubAccount("test.user@test.user")
+	createSubAccount := getCreateOrUpdateSubAccount("test.user@test.user")
 	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_sharing"
 	createSubAccount.SharingObjectsAccounts = nil
 	subAccount, err := underTest.CreateSubAccount(createSubAccount)

--- a/sub_accounts/sub_account_delete_integration_test.go
+++ b/sub_accounts/sub_account_delete_integration_test.go
@@ -9,7 +9,7 @@ import (
 func TestIntegrationSubAccount_DeleteSubAccount(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_delete"
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {

--- a/sub_accounts/sub_account_get_detailed_integration_test.go
+++ b/sub_accounts/sub_account_get_detailed_integration_test.go
@@ -10,7 +10,7 @@ func TestIntegrationSubAccount_GetDetailedSubAccount(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_get_detailed"
 
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)

--- a/sub_accounts/sub_account_get_integration_test.go
+++ b/sub_accounts/sub_account_get_integration_test.go
@@ -10,7 +10,7 @@ func TestIntegrationSubAccount_GetSubAccount(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		createSubAccount.AccountName = createSubAccount.AccountName + "_get"
 
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)

--- a/sub_accounts/sub_account_test.go
+++ b/sub_accounts/sub_account_test.go
@@ -49,7 +49,7 @@ func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, string, 
 	return underTest, email, err
 }
 
-func getCreatrOrUpdateSubAccount(email string) sub_accounts.CreateOrUpdateSubAccount {
+func getCreateOrUpdateSubAccount(email string) sub_accounts.CreateOrUpdateSubAccount {
 	subAccount := sub_accounts.CreateOrUpdateSubAccount{
 		Email:                  email,
 		AccountName:            "tf_client_test",
@@ -59,6 +59,10 @@ func getCreatrOrUpdateSubAccount(email string) sub_accounts.CreateOrUpdateSubAcc
 		Accessible:             strconv.FormatBool(true),
 		SharingObjectsAccounts: []int32{},
 		DocSizeSetting:         strconv.FormatBool(false),
+		UtilizationSettings: sub_accounts.AccountUtilizationSettingsCreateOrUpdate{
+			FrequencyMinutes:   3,
+			UtilizationEnabled: strconv.FormatBool(true),
+		},
 	}
 
 	*subAccount.MaxDailyGB = 1

--- a/sub_accounts/sub_account_update_integration_test.go
+++ b/sub_accounts/sub_account_update_integration_test.go
@@ -10,7 +10,7 @@ func TestIntegrationSubAccount_UpdateSubAccount(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 
 		subAccount, err := underTest.CreateSubAccount(createSubAccount)
 		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
@@ -35,7 +35,7 @@ func TestIntegrationSubAccount_UpdateSubAccount(t *testing.T) {
 func TestIntegrationSubAccount_UpdateSubAccountIdNotExists(t *testing.T) {
 	underTest, email, err := setupSubAccountsIntegrationTest()
 	if assert.NoError(t, err) {
-		createSubAccount := getCreatrOrUpdateSubAccount(email)
+		createSubAccount := getCreateOrUpdateSubAccount(email)
 		if assert.NoError(t, err) && assert.NotNil(t, createSubAccount) {
 			err = underTest.UpdateSubAccount(int64(1234567), createSubAccount)
 			assert.Error(t, err)

--- a/sub_accounts/sub_account_update_test.go
+++ b/sub_accounts/sub_account_update_test.go
@@ -29,7 +29,7 @@ func TestSubAccount_UpdateValidSubAccount(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	updateSubAccount := getCreatrOrUpdateSubAccount("test@user.test")
+	updateSubAccount := getCreateOrUpdateSubAccount("test@user.test")
 	err = underTest.UpdateSubAccount(subAccountId, updateSubAccount)
 	assert.NoError(t, err)
 }
@@ -53,7 +53,7 @@ func TestSubAccount_UpdateSubAccountIdNotFound(t *testing.T) {
 		fmt.Fprint(w, fixture("update_subaccount_not_fount.txt"))
 	})
 
-	updateSubAccount := getCreatrOrUpdateSubAccount("test@user.test")
+	updateSubAccount := getCreateOrUpdateSubAccount("test@user.test")
 	err = underTest.UpdateSubAccount(subAccountId, updateSubAccount)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed with missing sub account")


### PR DESCRIPTION
In this PR:
- `alerts_v2` - support new field `schedule`.
- Test for schedule.
- Improve sub_account tests (fix typo, better request)