### PR TITLE
Implement metrics_accounts

### DIFF
--- a/metrics_accounts/README.md
+++ b/metrics_accounts/README.md
@@ -1,0 +1,22 @@
+# Metrics sub-accounts
+
+Compatible with Logz.io's [account management API](https://docs.logz.io/api/#tag/Manage-metrics-account).
+
+To create a new metrics account, on a main account.
+```go
+client, _ := metrics_accounts.New(apiToken, apiServerAddress)
+account := metrics_accounts.CreateOrUpdateMetricsAccount{
+                Email:                  "some@email.test",
+                AccountName:            "tf_client_test",
+                PlanUts:                1000,
+                AuthorizedAccountsIds: []int32{},
+            }
+```
+
+| function               | func name                                                                                                                                       |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| create metrics account | `func (c *MetricsAccountClient) CreateMetricsAccount(createMetricsAccount CreateOrUpdateMetricsAccount) (*MetricsAccountCreateResponse, error)` |
+| update metrics account | `func (c *MetricsAccountClient) UpdateMetricsAccount(metricsAccountId int64, updateMetricsAccount CreateOrUpdateMetricsAccount) error`          |
+| delete metrics account | `func (c *MetricsAccountClient) DeleteMetricsAccount(metricsAccountId int64) error`                                                             |
+| get metrics account    | `func (c *MetricsAccountClient) GetMetricsAccount(metricsAccountId int64) (*MetricsAccount, error)`                                             |
+| list metrics accounts  | `func (c *MetricsAccountClient) ListMetricsAccounts() ([]MetricsAccount, error)`                                                                |

--- a/metrics_accounts/client_metrics_account.go
+++ b/metrics_accounts/client_metrics_account.go
@@ -1,0 +1,86 @@
+package metrics_accounts
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-hclog"
+	"github.com/logzio/logzio_terraform_client/client"
+)
+
+const (
+	metricsAccountServiceEndpoint = "%s/v1/account-management/metrics-accounts"
+	loggerName                    = "logzio-client"
+	operationGetMetricsAccount    = "GetMetricsAccount"
+	operationDeleteMetricsAccount = "DeleteMetricsAccount"
+	operationListMetricsAccounts  = "ListMetricsAccounts"
+	operationUpdateMetricsAccount = "UpdateMetricsAccount"
+	operationCreateMetricsAccount = "CreateMetricsAccount"
+
+	metricsAccountResourceName = "metrics account"
+)
+
+type MetricsAccountClient struct {
+	*client.Client
+	logger hclog.Logger
+}
+
+type CreateOrUpdateMetricsAccount struct {
+	Email                 string  `json:"email,omitempty"`
+	AccountName           string  `json:"accountName"`
+	PlanUts               int32   `json:"planUts"`
+	AuthorizedAccountsIds []int32 `json:"authorizedAccountsIds"`
+}
+
+type AccountUtilizationSettings struct {
+	FrequencyMinutes   int32 `json:"frequencyMinutes"`
+	UtilizationEnabled bool  `json:"utilizationEnabled"`
+}
+
+type MetricsAccount struct {
+	Id                    int32   `json:"Id"`
+	AccountName           string  `json:"accountName"`
+	Token                 string  `json:"token"`
+	CreatedAt             int64   `json:"createdAt"`
+	PlanUts               int32   `json:"planUts"`
+	AuthorizedAccountsIds []int32 `json:"authorizedAccountsIds"`
+}
+
+type AccountView struct {
+	AccountId       int32   `json:"accountId"`
+	AccountName     string  `json:"accountName"`
+	AccountToken    string  `json:"accountToken"`
+	Active          bool    `json:"active"`
+	EsIndexPrefix   string  `json:"esIndexPrefix"`
+	Flexible        bool    `json:"isFlexible"`
+	ReservedDailyGB float32 `json:"reservedDailyGB"`
+	MaxDailyGB      float32 `json:"maxDailyGB"`
+	RetentionDays   int32   `json:"retentionDays"`
+}
+
+type MetricsAccountCreateResponse struct {
+	Id                    int32   `json:"Id"`
+	AccountName           string  `json:"accountName"`
+	Token                 string  `json:"token"`
+	CreatedAt             int64   `json:"createdAt"`
+	PlanUts               int32   `json:"planUts"`
+	AuthorizedAccountsIds []int32 `json:"authorizedAccountsIds"`
+}
+
+// Creates a new entry point into the metrics-account functions, accepts the user's logz.io API token and account Id
+func New(apiToken string, baseUrl string) (*MetricsAccountClient, error) {
+	if len(apiToken) == 0 {
+		return nil, fmt.Errorf("API token not defined")
+	}
+	if len(baseUrl) == 0 {
+		return nil, fmt.Errorf("Base URL not defined")
+	}
+
+	c := &MetricsAccountClient{
+		Client: client.New(apiToken, baseUrl),
+		logger: hclog.New(&hclog.LoggerOptions{
+			Level:      hclog.Debug,
+			Name:       loggerName,
+			JSONFormat: true,
+		}),
+	}
+	return c, nil
+}

--- a/metrics_accounts/client_metrics_account_create.go
+++ b/metrics_accounts/client_metrics_account_create.go
@@ -1,0 +1,77 @@
+package metrics_accounts
+
+import (
+	"encoding/json"
+	"fmt"
+	logzio_client "github.com/logzio/logzio_terraform_client"
+	"net/http"
+)
+
+const (
+	createMetricsAccountServiceUrl     = metricsAccountServiceEndpoint
+	createMetricsAccountServiceMethod  = http.MethodPost
+	createMetricsAccountMethodSuccess  = http.StatusOK
+	createMetricsAccountStatusNotFound = http.StatusNotFound
+)
+
+type FieldError struct {
+	Field   string
+	Message string
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf("%v: %v", e.Field, e.Message)
+}
+
+// CreateMetricsAccount creates metrics account, return account's id & token if successful, an error otherwise
+func (c *MetricsAccountClient) CreateMetricsAccount(createSubAccount CreateOrUpdateMetricsAccount) (*MetricsAccountCreateResponse, error) {
+	err := validateCreateMetricsAccount(createSubAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	SubAccountJson, err := json.Marshal(createSubAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
+		ApiToken:     c.ApiToken,
+		HttpMethod:   createMetricsAccountServiceMethod,
+		Url:          fmt.Sprintf(createMetricsAccountServiceUrl, c.BaseUrl),
+		Body:         SubAccountJson,
+		SuccessCodes: []int{createMetricsAccountMethodSuccess},
+		NotFoundCode: createMetricsAccountStatusNotFound,
+		ResourceId:   nil,
+		ApiAction:    operationCreateMetricsAccount,
+		ResourceName: metricsAccountResourceName,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var reVal MetricsAccountCreateResponse
+	err = json.Unmarshal(res, &reVal)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reVal, nil
+}
+
+func validateCreateMetricsAccount(createSubAccount CreateOrUpdateMetricsAccount) error {
+	if len(createSubAccount.Email) == 0 {
+		return fmt.Errorf("email must be set")
+	}
+
+	if createSubAccount.AuthorizedAccountsIds == nil {
+		return fmt.Errorf("authorized accounts must be initialized, even without any ids")
+	}
+
+	if createSubAccount.PlanUts < 100 {
+		return fmt.Errorf("planUts should be >= 100")
+	}
+
+	return nil
+}

--- a/metrics_accounts/client_metrics_account_delete.go
+++ b/metrics_accounts/client_metrics_account_delete.go
@@ -1,0 +1,31 @@
+package metrics_accounts
+
+import (
+	"fmt"
+	logzio_client "github.com/logzio/logzio_terraform_client"
+	"net/http"
+)
+
+const (
+	deleteMetricsAccountServiceUrl     = metricsAccountServiceEndpoint + "/%d"
+	deleteMetricsAccountServiceMethod  = http.MethodDelete
+	deleteMetricsAccountServiceSuccess = 200
+	deleteMetricsAccountMethodNotFound = http.StatusNoContent
+)
+
+// DeleteMetricsAccount deletes a metrics account specified by its unique id, returns an error if a problem is encountered
+func (c *MetricsAccountClient) DeleteMetricsAccount(metricsAccountId int64) error {
+	_, err := logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
+		ApiToken:     c.ApiToken,
+		HttpMethod:   deleteMetricsAccountServiceMethod,
+		Url:          fmt.Sprintf(deleteMetricsAccountServiceUrl, c.BaseUrl, metricsAccountId),
+		Body:         nil,
+		SuccessCodes: []int{deleteMetricsAccountServiceSuccess},
+		NotFoundCode: deleteMetricsAccountMethodNotFound,
+		ResourceId:   metricsAccountId,
+		ApiAction:    operationDeleteMetricsAccount,
+		ResourceName: metricsAccountResourceName,
+	})
+
+	return err
+}

--- a/metrics_accounts/client_metrics_account_get.go
+++ b/metrics_accounts/client_metrics_account_get.go
@@ -1,0 +1,42 @@
+package metrics_accounts
+
+import (
+	"encoding/json"
+	"fmt"
+	logzio_client "github.com/logzio/logzio_terraform_client"
+	"net/http"
+)
+
+const (
+	getMetricsAccountServiceUrl      = metricsAccountServiceEndpoint + "/%d"
+	getMetricsAccountServiceMethod   = http.MethodGet
+	getMetricsAccountServiceSuccess  = http.StatusOK
+	getMetricsAccountServiceNotFound = http.StatusNotFound
+)
+
+// GetMetricsAccount returns a metrics account given its unique identifier, an error otherwise
+func (c *MetricsAccountClient) GetMetricsAccount(metricsAccountId int64) (*MetricsAccount, error) {
+	res, err := logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
+		ApiToken:     c.ApiToken,
+		HttpMethod:   getMetricsAccountServiceMethod,
+		Url:          fmt.Sprintf(getMetricsAccountServiceUrl, c.BaseUrl, metricsAccountId),
+		Body:         nil,
+		SuccessCodes: []int{getMetricsAccountServiceSuccess},
+		NotFoundCode: getMetricsAccountServiceNotFound,
+		ResourceId:   metricsAccountId,
+		ApiAction:    operationGetMetricsAccount,
+		ResourceName: metricsAccountResourceName,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var subAccount MetricsAccount
+	err = json.Unmarshal(res, &subAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	return &subAccount, nil
+}

--- a/metrics_accounts/client_metrics_account_list.go
+++ b/metrics_accounts/client_metrics_account_list.go
@@ -1,0 +1,43 @@
+package metrics_accounts
+
+import (
+	"encoding/json"
+	"fmt"
+	logzio_client "github.com/logzio/logzio_terraform_client"
+	"net/http"
+)
+
+const (
+	listMetricsAccountServiceUrl     = metricsAccountServiceEndpoint
+	listMetricsAccountServiceMethod  = http.MethodGet
+	listMetricsAccountServiceSuccess = http.StatusOK
+	listMetricsAccountStatusNotFound = http.StatusNotFound
+)
+
+// ListMetricsAccounts returns all the metrics accounts in an array associated with the account identified by the supplied API token, returns an error if
+// any problem occurs during the API call
+func (c *MetricsAccountClient) ListMetricsAccounts() ([]MetricsAccount, error) {
+	res, err := logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
+		ApiToken:     c.ApiToken,
+		HttpMethod:   listMetricsAccountServiceMethod,
+		Url:          fmt.Sprintf(listMetricsAccountServiceUrl, c.BaseUrl),
+		Body:         nil,
+		SuccessCodes: []int{listMetricsAccountServiceSuccess},
+		NotFoundCode: listMetricsAccountStatusNotFound,
+		ResourceId:   nil,
+		ApiAction:    operationListMetricsAccounts,
+		ResourceName: metricsAccountResourceName,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var subAccounts []MetricsAccount
+	err = json.Unmarshal(res, &subAccounts)
+	if err != nil {
+		return nil, err
+	}
+
+	return subAccounts, nil
+}

--- a/metrics_accounts/client_metrics_account_update.go
+++ b/metrics_accounts/client_metrics_account_update.go
@@ -1,0 +1,53 @@
+package metrics_accounts
+
+import (
+	"encoding/json"
+	"fmt"
+	logzio_client "github.com/logzio/logzio_terraform_client"
+	"net/http"
+)
+
+const (
+	updateMetricsAccountServiceUrl      = metricsAccountServiceEndpoint + "/%d"
+	updateMetricsAccountServiceMethod   = http.MethodPut
+	updateMetricsAccountServiceSuccess  = 200
+	updateMetricsAccountServiceNotFound = http.StatusNotFound
+)
+
+func (c *MetricsAccountClient) UpdateMetricsAccount(metricsAccountId int64, updateMetricsAccount CreateOrUpdateMetricsAccount) error {
+	err := validateUpdateSubAccount(updateMetricsAccount)
+	if err != nil {
+		return err
+	}
+
+	updateSubAccountJson, err := json.Marshal(updateMetricsAccount)
+	if err != nil {
+		return err
+	}
+
+	_, err = logzio_client.CallLogzioApi(logzio_client.LogzioApiCallDetails{
+		ApiToken:     c.ApiToken,
+		HttpMethod:   updateMetricsAccountServiceMethod,
+		Url:          fmt.Sprintf(updateMetricsAccountServiceUrl, c.BaseUrl, metricsAccountId),
+		Body:         updateSubAccountJson,
+		SuccessCodes: []int{updateMetricsAccountServiceSuccess},
+		NotFoundCode: updateMetricsAccountServiceNotFound,
+		ResourceId:   metricsAccountId,
+		ApiAction:    operationUpdateMetricsAccount,
+		ResourceName: metricsAccountResourceName,
+	})
+
+	return err
+}
+
+func validateUpdateSubAccount(updateSubAccount CreateOrUpdateMetricsAccount) error {
+	if len(updateSubAccount.AccountName) == 0 {
+		return fmt.Errorf("account name must be set")
+	}
+
+	if updateSubAccount.PlanUts < 0 {
+		return fmt.Errorf("PlanUts should be >=100 or empty")
+	}
+
+	return nil
+}

--- a/metrics_accounts/metrics_account_create_integration_test.go
+++ b/metrics_accounts/metrics_account_create_integration_test.go
@@ -1,0 +1,82 @@
+package metrics_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/test_utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationMetricsAccount_CreateMetricsAccount(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		createSubAccount.AccountName = createSubAccount.AccountName + "_create"
+
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteMetricsAccount(int64(subAccount.Id))
+			assert.NotEmpty(t, subAccount.Token)
+			assert.NotEmpty(t, subAccount.Id)
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_CreateMetricsAccountWithSharingAccount(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		accountId, err := test_utils.GetAccountId()
+		assert.NoError(t, err)
+
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		createSubAccount.AccountName = createSubAccount.AccountName + "_create_with_sharing_account"
+		createSubAccount.AuthorizedAccountsIds = []int32{int32(accountId)}
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteMetricsAccount(int64(subAccount.Id))
+			assert.NotEmpty(t, subAccount.Token)
+			assert.NotEmpty(t, subAccount.Id)
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_CreateMetricsAccountInvalidMail(t *testing.T) {
+	underTest, _, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount("invalid@mail.test")
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}
+
+func TestIntegrationMetricsAccount_CreateMetricsAccountNoMail(t *testing.T) {
+	underTest, _, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount("")
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}
+
+func TestIntegrationMetricsAccount_CreateMetricsAccountNoAccountName(t *testing.T) { //TODO rewrite
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		createSubAccount.AccountName = ""
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}

--- a/metrics_accounts/metrics_account_create_test.go
+++ b/metrics_accounts/metrics_account_create_test.go
@@ -1,0 +1,119 @@
+package metrics_accounts_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/logzio/logzio_terraform_client/metrics_accounts"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestMetricsAccount_CreateValidMetricsAccount(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	if assert.NoError(t, err) {
+		mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			var target metrics_accounts.CreateOrUpdateMetricsAccount
+			err = json.Unmarshal(jsonBytes, &target)
+			assert.NoError(t, err)
+			assert.NotNil(t, target)
+			assert.NotEmpty(t, target.Email)
+			assert.NotEmpty(t, target.AccountName)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, fixture("create_metrics_account.json"))
+		})
+
+		createSubAccount := getCreateOrUpdateMetricsAccount("test.user@test.user")
+		createSubAccount.AccountName = createSubAccount.AccountName + "_test_create"
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		assert.NoError(t, err)
+		assert.NotNil(t, subAccount)
+		assert.NotEmpty(t, subAccount.Id)
+		assert.NotEmpty(t, subAccount.Token)
+	}
+}
+
+func TestMetricsAccount_CreateValidMetricsAccountAPIFail(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	if assert.NoError(t, err) {
+		mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, fixture("create_metrics_account_failed.txt"))
+		})
+
+		createSubAccount := getCreateOrUpdateMetricsAccount("test.user@test.user")
+		createSubAccount.AccountName = createSubAccount.AccountName + "_test_create"
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}
+
+func TestMetricsAccount_CreateMetricsAccountNoEmail(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	createSubAccount := getCreateOrUpdateMetricsAccount("")
+	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_email"
+	subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+	assert.Error(t, err)
+	assert.Nil(t, subAccount)
+}
+
+func TestMetricsAccount_CreateMetricsAccountNoAccountName(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	if assert.NoError(t, err) {
+		mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			var target metrics_accounts.CreateOrUpdateMetricsAccount
+			err = json.Unmarshal(jsonBytes, &target)
+			assert.NoError(t, err)
+			assert.NotNil(t, target)
+			assert.NotEmpty(t, target.Email)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, fixture("create_metrics_account_generatename.json"))
+		})
+
+		createSubAccount := getCreateOrUpdateMetricsAccount("test.user@test.user")
+		createSubAccount.AccountName = ""
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		assert.NoError(t, err)
+		assert.NotNil(t, subAccount)
+		assert.NotEmpty(t, subAccount.AccountName)
+	}
+}
+
+func TestMetricsAccount_CreateMetricsAccountNoPlanUts(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	createSubAccount := getCreateOrUpdateMetricsAccount("test.user@test.user")
+	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_planuts"
+	createSubAccount.PlanUts = -1
+	subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+	assert.Error(t, err)
+	assert.Nil(t, subAccount)
+}
+
+func TestMetricsAccount_CreateMetricsAccountNoSharingAccount(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	defer teardown()
+
+	createSubAccount := getCreateOrUpdateMetricsAccount("test.user@test.user")
+	createSubAccount.AccountName = createSubAccount.AccountName + "_test_create_no_sharing"
+	createSubAccount.AuthorizedAccountsIds = nil
+	subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+	assert.Error(t, err)
+	assert.Nil(t, subAccount)
+}

--- a/metrics_accounts/metrics_account_delete_integration_test.go
+++ b/metrics_accounts/metrics_account_delete_integration_test.go
@@ -1,0 +1,32 @@
+package metrics_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationMetricsAccount_DeleteMetricsAccount(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		createSubAccount.AccountName = createSubAccount.AccountName + "_delete"
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(2 * time.Second)
+			defer func() {
+				err = underTest.DeleteMetricsAccount(int64(subAccount.Id))
+				assert.NoError(t, err)
+			}()
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_DeleteMetricsAccountNotExists(t *testing.T) {
+	underTest, _, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		err = underTest.DeleteMetricsAccount(int64(1234567))
+		assert.Error(t, err)
+	}
+}

--- a/metrics_accounts/metrics_account_delete_test.go
+++ b/metrics_accounts/metrics_account_delete_test.go
@@ -1,0 +1,45 @@
+package metrics_accounts_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestMetricsAccount_DeleteValidMetricsAccount(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(1234567)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(subAccountId, 10))
+		w.WriteHeader(200) //deleteAccountMetricsSuccess
+	})
+
+	err = underTest.DeleteMetricsAccount(subAccountId)
+	assert.NoError(t, err)
+}
+
+func TestMetricsAccount_DeleteValidMetricsAccountNotFound(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(12345)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(subAccountId, 10))
+		w.WriteHeader(http.StatusNoContent) //deleteMetricsAccountMethodNotFound
+		fmt.Fprint(w, fixture("delete_metrics_account_failed.txt"))
+	})
+
+	err = underTest.DeleteMetricsAccount(subAccountId)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed with missing metrics account")
+}

--- a/metrics_accounts/metrics_account_get_integration_test.go
+++ b/metrics_accounts/metrics_account_get_integration_test.go
@@ -1,0 +1,37 @@
+package metrics_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationMetricsAccount_GetMetricsAccount(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		createSubAccount.AccountName = createSubAccount.AccountName + "_get"
+
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			defer underTest.DeleteMetricsAccount(int64(subAccount.Id))
+			time.Sleep(4 * time.Second)
+			getSubAccount, err := underTest.GetMetricsAccount(int64(subAccount.Id))
+			assert.NoError(t, err)
+			assert.NotNil(t, getSubAccount)
+			assert.Equal(t, subAccount.Id, getSubAccount.Id)
+			assert.Equal(t, createSubAccount.AccountName, getSubAccount.AccountName)
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_GetMetricsAccountNotExists(t *testing.T) {
+	underTest, _, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		subAccount, err := underTest.GetMetricsAccount(int64(1234567))
+		assert.Error(t, err)
+		assert.Nil(t, subAccount)
+	}
+}

--- a/metrics_accounts/metrics_account_get_test.go
+++ b/metrics_accounts/metrics_account_get_test.go
@@ -1,0 +1,53 @@
+package metrics_accounts_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestMetricsAccount_GetValidMetricsAccount(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(1234567)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(subAccountId), 10))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("get_metrics_account.json"))
+	})
+
+	subAccount, err := underTest.GetMetricsAccount(subAccountId)
+	assert.NoError(t, err)
+	assert.NotNil(t, subAccount)
+	assert.Equal(t, int32(1234567), subAccount.Id)
+	//assert.Empty(t, subAccount.Email)
+	assert.Equal(t, "testAccount", subAccount.AccountName)
+	assert.Equal(t, int32(5), subAccount.PlanUts)
+	assert.Equal(t, len(subAccount.AuthorizedAccountsIds), 1)
+}
+
+func TestMetricsAccount_GetValidMetricsAccountNotFound(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(1234567)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(subAccountId), 10))
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, fixture("get_metrics_account_not_found.txt"))
+	})
+
+	subAccount, err := underTest.GetMetricsAccount(subAccountId)
+	assert.Error(t, err)
+	assert.Nil(t, subAccount)
+	assert.Contains(t, err.Error(), "failed with missing metrics account")
+}

--- a/metrics_accounts/metrics_account_list_integration_test.go
+++ b/metrics_accounts/metrics_account_list_integration_test.go
@@ -1,0 +1,16 @@
+package metrics_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIntegrationSubAccount_ListSubAccounts(t *testing.T) {
+	underTest, _, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		subAccounts, err := underTest.ListMetricsAccounts()
+		assert.NoError(t, err)
+		assert.NotNil(t, subAccounts)
+	}
+}

--- a/metrics_accounts/metrics_account_list_test.go
+++ b/metrics_accounts/metrics_account_list_test.go
@@ -1,0 +1,42 @@
+package metrics_accounts_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestMetricsAccount_ListMetricsAccounts(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("list_metrics_accounts.json"))
+	})
+
+	subAccounts, err := underTest.ListMetricsAccounts()
+	assert.NoError(t, err)
+	assert.NotNil(t, subAccounts)
+	assert.Equal(t, 1, len(subAccounts))
+}
+
+func TestSubAccount_ListSubAccountsAPIFail(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, fixture("list_metrics_accounts_failed.txt"))
+	})
+
+	subAccounts, err := underTest.ListMetricsAccounts()
+	assert.Error(t, err)
+	assert.Nil(t, subAccounts)
+}

--- a/metrics_accounts/metrics_account_test.go
+++ b/metrics_accounts/metrics_account_test.go
@@ -1,0 +1,60 @@
+package metrics_accounts_test
+
+import (
+	"github.com/logzio/logzio_terraform_client/metrics_accounts"
+	"github.com/logzio/logzio_terraform_client/test_utils"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+)
+
+var (
+	mux    *http.ServeMux
+	server *httptest.Server
+)
+
+func fixture(path string) string {
+	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func setupMetricsAccountsTest() (*metrics_accounts.MetricsAccountClient, error, func()) {
+	mux = http.NewServeMux()
+	server = httptest.NewServer(mux)
+
+	apiToken := "SOME_API_TOKEN"
+	underTest, _ := metrics_accounts.New(apiToken, server.URL)
+
+	return underTest, nil, func() {
+		server.Close()
+	}
+}
+
+func setupMetricsAccountsIntegrationTest() (*metrics_accounts.MetricsAccountClient, string, error) {
+	apiToken, err := test_utils.GetApiToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	email, err := test_utils.GetLogzioEmail()
+	if err != nil {
+		return nil, "", err
+	}
+
+	underTest, err := metrics_accounts.New(apiToken, test_utils.GetLogzIoBaseUrl())
+	return underTest, email, err
+}
+
+func getCreateOrUpdateMetricsAccount(email string) metrics_accounts.CreateOrUpdateMetricsAccount {
+	subAccount := metrics_accounts.CreateOrUpdateMetricsAccount{
+		Email:                 email,
+		AccountName:           "tf_client_test",
+		PlanUts:               100,
+		AuthorizedAccountsIds: []int32{},
+	}
+
+	return subAccount
+}

--- a/metrics_accounts/metrics_account_update_integration_test.go
+++ b/metrics_accounts/metrics_account_update_integration_test.go
@@ -1,0 +1,44 @@
+package metrics_accounts_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestIntegrationMetricsAccount_UpdateMetricsAccount(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+
+		subAccount, err := underTest.CreateMetricsAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			defer underTest.DeleteMetricsAccount(int64(subAccount.Id))
+			time.Sleep(time.Second * 2)
+			getSubAccount, err := underTest.GetMetricsAccount(int64(subAccount.Id))
+			assert.NoError(t, err)
+			assert.Equal(t, "tf_client_test", getSubAccount.AccountName)
+			createSubAccount.AccountName = "test_after_update"
+			time.Sleep(time.Second * 2)
+			err = underTest.UpdateMetricsAccount(int64(subAccount.Id), createSubAccount)
+			assert.NoError(t, err)
+			// verify that the update was made
+			time.Sleep(time.Second * 2)
+			getSubAccount, err = underTest.GetMetricsAccount(int64(subAccount.Id))
+			assert.NoError(t, err)
+			assert.Equal(t, "test_after_update", getSubAccount.AccountName)
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_UpdateMetricsAccountIdNotExists(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateMetricsAccount(email)
+		if assert.NoError(t, err) && assert.NotNil(t, createSubAccount) {
+			err = underTest.UpdateMetricsAccount(int64(1234567), createSubAccount)
+			assert.Error(t, err)
+		}
+	}
+}

--- a/metrics_accounts/metrics_account_update_test.go
+++ b/metrics_accounts/metrics_account_update_test.go
@@ -1,0 +1,60 @@
+package metrics_accounts_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/logzio/logzio_terraform_client/metrics_accounts"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestMetricsAccount_UpdateValidMetricsAccount(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(1234567)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(subAccountId), 10))
+		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		var target metrics_accounts.CreateOrUpdateMetricsAccount
+		err = json.Unmarshal(jsonBytes, &target)
+		assert.NoError(t, err)
+		assert.NotNil(t, target)
+		w.WriteHeader(200) //updateMetricsAccountServiceSuccess
+	})
+
+	updateSubAccount := getCreateOrUpdateMetricsAccount("test@user.test")
+	err = underTest.UpdateMetricsAccount(subAccountId, updateSubAccount)
+	assert.NoError(t, err)
+}
+
+func TestMetricsAccount_UpdateMetricsAccountIdNotFound(t *testing.T) {
+	underTest, err, teardown := setupMetricsAccountsTest()
+	assert.NoError(t, err)
+	defer teardown()
+
+	subAccountId := int64(1234567)
+
+	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(subAccountId), 10))
+		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		var target metrics_accounts.CreateOrUpdateMetricsAccount
+		err = json.Unmarshal(jsonBytes, &target)
+		assert.NoError(t, err)
+		assert.NotNil(t, target)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, fixture("update_metrics_account_not_fount.txt"))
+	})
+
+	updateSubAccount := getCreateOrUpdateMetricsAccount("test@user.test")
+	err = underTest.UpdateMetricsAccount(subAccountId, updateSubAccount)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed with missing metrics account")
+}

--- a/metrics_accounts/testdata/fixtures/create_metrics_account.json
+++ b/metrics_accounts/testdata/fixtures/create_metrics_account.json
@@ -1,0 +1,10 @@
+{
+  "id": 99999,
+  "accountName": "testAccount",
+  "token": "x93afghvexbn841h45vkjn5",
+  "createdAt": 1685018347000,
+  "planUts": 100,
+  "authorizedAccountsIds": [
+    0
+  ]
+}

--- a/metrics_accounts/testdata/fixtures/create_metrics_account_failed.txt
+++ b/metrics_accounts/testdata/fixtures/create_metrics_account_failed.txt
@@ -1,0 +1,1 @@
+"Failed to create metrics account"

--- a/metrics_accounts/testdata/fixtures/create_metrics_account_generatename.json
+++ b/metrics_accounts/testdata/fixtures/create_metrics_account_generatename.json
@@ -1,0 +1,10 @@
+{
+  "id": 99999,
+  "accountName": "ownerAccountName_metrics",
+  "token": "x93afghvexbn841h45vkjn5",
+  "createdAt": 1685018347000,
+  "planUts": 0,
+  "authorizedAccountsIds": [
+    0
+  ]
+}

--- a/metrics_accounts/testdata/fixtures/delete_metrics_account_failed.txt
+++ b/metrics_accounts/testdata/fixtures/delete_metrics_account_failed.txt
@@ -1,0 +1,1 @@
+"Could not find metrics account 12345"

--- a/metrics_accounts/testdata/fixtures/get_metrics_account.json
+++ b/metrics_accounts/testdata/fixtures/get_metrics_account.json
@@ -1,0 +1,10 @@
+{
+  "id": 1234567,
+  "accountName": "testAccount",
+  "token": "string",
+  "createdAt": 1685018347000,
+  "planUts": 5,
+  "authorizedAccountsIds": [
+    0
+  ]
+}

--- a/metrics_accounts/testdata/fixtures/get_metrics_account_not_found.txt
+++ b/metrics_accounts/testdata/fixtures/get_metrics_account_not_found.txt
@@ -1,0 +1,1 @@
+"could not find metrics account 1234567"

--- a/metrics_accounts/testdata/fixtures/list_metrics_accounts.json
+++ b/metrics_accounts/testdata/fixtures/list_metrics_accounts.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1234567,
+    "accountName": "testAccount",
+    "token": "string",
+    "createdAt": 1685018347000,
+    "planUts": 0,
+    "authorizedAccountsIds": [
+      0
+    ]
+  }
+]

--- a/metrics_accounts/testdata/fixtures/list_metrics_accounts_failed.txt
+++ b/metrics_accounts/testdata/fixtures/list_metrics_accounts_failed.txt
@@ -1,0 +1,1 @@
+"could not retrieve metrics accounts"

--- a/metrics_accounts/testdata/fixtures/update_metrics_account_not_fount.txt
+++ b/metrics_accounts/testdata/fixtures/update_metrics_account_not_fount.txt
@@ -1,0 +1,1 @@
+"metrics account 1234567 not exists"


### PR DESCRIPTION
A straightforward copy-paste and refactor of `sub_accounts` module into `metrics_accounts` for managing [metrics sub-accounts](https://docs.logz.io/api/#tag/Manage-metrics-account).

Tests passed on a trial account:
![image](https://github.com/logzio/logzio_terraform_client/assets/6135211/d991d6d4-236e-4be7-b320-ec7bca770be1)


NOTE: the create API is rather slow and returns a "504 Gateway Timeout" randomly, so tests might be flaky. One can workaround the issue by instrumenting the client with a list after timeout to check if create operation succeeded (finding by name) and reconstruct original response, but the best fix is to re-configure the gateway on server side to allow larger timeouts (at least for this part of the API). In the Logz.io UI, this problem is solved somehow (UI doesn't use API directly); it only exists for the API.