### PR TITLE
Add validation to grafana alert name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The library currently supports the following API endpoints:
   <summary markdown="span">Exapnd to check old versions </summary>
 
 - v1.16.1
-  - Add limitation, Grafana Folder name cannot contain `/`.
+  - Add limitation, Grafana Folder name cannot contain `/` or `\`.
 - v1.16.0
   - Add [Grafana Dashboards API](https://docs.logz.io/api/#operation/createDashboard) support.
 - v1.15.0

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The library currently supports the following API endpoints:
 <details>
   <summary markdown="span">Exapnd to check old versions </summary>
 
+- v1.16.1
+  - Add limitation, Grafana Folder name cannot contain `/`.
 - v1.16.0
   - Add [Grafana Dashboards API](https://docs.logz.io/api/#operation/createDashboard) support.
 - v1.15.0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The library currently supports the following API endpoints:
   <summary markdown="span">Exapnd to check old versions </summary>
 
 - v1.16.1
-  - Add limitation, Grafana Folder name cannot contain `/` or `\`.
+  - Add limitation, Grafana Alert name cannot contain `/` or `\`.
 - v1.16.0
   - Add [Grafana Dashboards API](https://docs.logz.io/api/#operation/createDashboard) support.
 - v1.15.0

--- a/grafana_alerts/client_grafana_alert.go
+++ b/grafana_alerts/client_grafana_alert.go
@@ -3,6 +3,7 @@ package grafana_alerts
 import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/client"
+	"strings"
 	"time"
 )
 
@@ -110,6 +111,8 @@ func validateGrafanaAlertRuleCreateUpdate(payload GrafanaAlertRule, isUpdate boo
 
 	if len(payload.Title) == 0 {
 		return fmt.Errorf("Field title must be set!")
+	} else if strings.Contains(payload.Title, "\\") || strings.Contains(payload.Title, "/") {
+		return fmt.Errorf("alert Title cannot contain '/' or '\\\\' charchters")
 	}
 
 	if isUpdate {

--- a/grafana_alerts/grafana_alert_create_integration_test.go
+++ b/grafana_alerts/grafana_alert_create_integration_test.go
@@ -102,3 +102,23 @@ func TestIntegrationGrafanaAlert_CreateGrafanaAlertNoOrgRuleGroup(t *testing.T) 
 		assert.Nil(t, grafanaAlert)
 	}
 }
+
+func TestIntegrationGrafanaAlert_CreateGrafanaAlertInvalidTitle(t *testing.T) {
+	underTest, err := setupGrafanaAlertIntegrationTest()
+	defer test_utils.TestDoneTimeBuffer()
+
+	if assert.NoError(t, err) {
+		// test '/' naming limitation
+		createGrafanaAlert := getGrafanaAlertRuleObject()
+		createGrafanaAlert.Title = "client/test/title"
+		grafanaAlert, err := underTest.CreateGrafanaAlertRule(createGrafanaAlert)
+		assert.Error(t, err)
+		assert.Nil(t, grafanaAlert)
+
+		// test '\' naming limitation
+		createGrafanaAlert.Title = "client\\test\\title"
+		grafanaAlert, err = underTest.CreateGrafanaAlertRule(createGrafanaAlert)
+		assert.Error(t, err)
+		assert.Nil(t, grafanaAlert)
+	}
+}


### PR DESCRIPTION
Following ICR-216
- add validation that the alert name cannot contain `\` or `/`
- add tests regarding it
- update readme