### PR TITLE
update tests

### DIFF
--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -29,9 +29,9 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.18
       - name: Test

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.22
       - name: Test
         # We exclude kibana_objects tests
         run: go test $(go list ./... | grep -v kibana_objects)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.22
     - name: Before install
       run: |
         go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.18
     - name: Before install

--- a/metrics_accounts/metrics_account_create_integration_test.go
+++ b/metrics_accounts/metrics_account_create_integration_test.go
@@ -76,7 +76,12 @@ func TestIntegrationMetricsAccount_CreateMetricsAccountNoAccountName(t *testing.
 		createMetricsAccount.AccountName = ""
 		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
 
-		assert.Error(t, err)
-		assert.Nil(t, metricsAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, metricsAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteMetricsAccount(int64(metricsAccount.Id))
+			assert.NotEmpty(t, metricsAccount.Token)
+			assert.NotEmpty(t, metricsAccount.Id)
+			assert.Equal(t, metricsAccount.AccountName, "IntegrationsTeamTesting_metrics")
+		}
 	}
 }


### PR DESCRIPTION
this pr closes #121 and closes #122 

- upgrade workflows versions 
- change metric account create account test logic
  - so far expected an error (since an account with the name already existed in the tests account)
  - but it clashes with [terraform provider PR tests](https://github.com/logzio/terraform-provider-logzio/pull/187) that expect an account with default name to be created and deleted
  - so changed the logic here to be the same (for the account to be created successfully and deleted)