### PR TITLE
[bugfix] v1.22.0 handle update uts for existing accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The library currently supports the following API endpoints:
 
 ### Changelog
 
+- 1.22.0
+  - Validate account existence before updating it, and set an empty account name If the name did not change to prevent api errors.
 - 1.21.0
   - Add [Metrics Accounts API](https://api-docs.logz.io/docs/logz/create-a-new-metrics-account).
 - 1.20.1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The library currently supports the following API endpoints:
 ### Changelog
 
 - 1.22.0
-  - Validate account existence before updating it, and set an empty account name If the name did not change to prevent api errors.
+  - Validate account existence before updating it, and set an empty account name if the name did not change to prevent API errors.
 - 1.21.0
   - Add [Metrics Accounts API](https://api-docs.logz.io/docs/logz/create-a-new-metrics-account).
 - 1.20.1

--- a/metrics_accounts/client_metrics_account_get.go
+++ b/metrics_accounts/client_metrics_account_get.go
@@ -31,7 +31,9 @@ func (c *MetricsAccountClient) GetMetricsAccount(metricsAccountId int64) (*Metri
 	if err != nil {
 		return nil, err
 	}
-
+	if len(res) == 0 {
+		return nil, fmt.Errorf("failed with missing metrics account")
+	}
 	var metricsAccount MetricsAccount
 	err = json.Unmarshal(res, &metricsAccount)
 	if err != nil {

--- a/metrics_accounts/client_metrics_account_update.go
+++ b/metrics_accounts/client_metrics_account_update.go
@@ -19,7 +19,13 @@ func (c *MetricsAccountClient) UpdateMetricsAccount(metricsAccountId int64, upda
 	if err != nil {
 		return err
 	}
-
+	currentAccount, err := c.GetMetricsAccount(metricsAccountId)
+	if err != nil {
+		return err
+	}
+	if currentAccount.AccountName == updateMetricsAccount.AccountName {
+		updateMetricsAccount.AccountName = ""
+	}
 	updateMetricsAccountJson, err := json.Marshal(updateMetricsAccount)
 	if err != nil {
 		return err

--- a/metrics_accounts/metrics_account_update_integration_test.go
+++ b/metrics_accounts/metrics_account_update_integration_test.go
@@ -31,6 +31,47 @@ func TestIntegrationMetricsAccount_UpdateMetricsAccount(t *testing.T) {
 		}
 	}
 }
+func TestIntegrationMetricsAccount_UpdateMetricsAccountPlanUts(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createMetricsAccount := getCreateOrUpdateMetricsAccount(email)
+		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, metricsAccount) {
+			defer underTest.DeleteMetricsAccount(int64(metricsAccount.Id))
+			time.Sleep(time.Second * 2)
+			// Update the plan_uts field without changing the account_name
+			createMetricsAccount.PlanUts = new(int32)
+			*createMetricsAccount.PlanUts = 200
+			err = underTest.UpdateMetricsAccount(int64(metricsAccount.Id), createMetricsAccount)
+			assert.Error(t, err)
+			// Check if the error message is as expected
+			assert.Contains(t, err.Error(), "Sub account with name (TEST_AUTOMATION_ACCOUNT) already exists on account")
+		}
+	}
+}
+
+func TestIntegrationMetricsAccount_UpdateMetricsAccountWithAuthorizedAccounts(t *testing.T) {
+	underTest, email, err := setupMetricsAccountsIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createMetricsAccount := getCreateOrUpdateMetricsAccount(email)
+		// Add an authorized account
+		createMetricsAccount.AuthorizedAccountsIds = append(createMetricsAccount.AuthorizedAccountsIds, 123456)
+		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, metricsAccount) {
+			defer underTest.DeleteMetricsAccount(int64(metricsAccount.Id))
+			time.Sleep(time.Second * 2)
+			// Update the plan_uts field
+			createMetricsAccount.PlanUts = new(int32)
+			*createMetricsAccount.PlanUts = 200
+			err = underTest.UpdateMetricsAccount(int64(metricsAccount.Id), createMetricsAccount)
+			assert.Error(t, err)
+			// Check if the error message is as expected
+			assert.Contains(t, err.Error(), "Sub account is not found for the owner account")
+		}
+	}
+}
 
 func TestIntegrationMetricsAccount_UpdateMetricsAccountIdNotExists(t *testing.T) {
 	underTest, email, err := setupMetricsAccountsIntegrationTest()

--- a/metrics_accounts/metrics_account_update_integration_test.go
+++ b/metrics_accounts/metrics_account_update_integration_test.go
@@ -42,7 +42,8 @@ func TestIntegrationMetricsAccount_UpdateMetricsAccountPlanUts(t *testing.T) {
 			*createMetricsAccount.PlanUts = 200
 			err = underTest.UpdateMetricsAccount(int64(metricsAccount.Id), createMetricsAccount)
 			assert.NoError(t, err)
-
+			assert.Equal(t, int32(200), *createMetricsAccount.PlanUts)
+			assert.Equal(t, "tf_client_test", metricsAccount.AccountName)
 		}
 	}
 }

--- a/metrics_accounts/metrics_account_update_integration_test.go
+++ b/metrics_accounts/metrics_account_update_integration_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestIntegrationMetricsAccount_UpdateMetricsAccount(t *testing.T) {
 	underTest, email, err := setupMetricsAccountsIntegrationTest()
-
 	if assert.NoError(t, err) {
 		createMetricsAccount := getCreateOrUpdateMetricsAccount(email)
 		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
@@ -33,42 +32,17 @@ func TestIntegrationMetricsAccount_UpdateMetricsAccount(t *testing.T) {
 }
 func TestIntegrationMetricsAccount_UpdateMetricsAccountPlanUts(t *testing.T) {
 	underTest, email, err := setupMetricsAccountsIntegrationTest()
-
 	if assert.NoError(t, err) {
 		createMetricsAccount := getCreateOrUpdateMetricsAccount(email)
 		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
 		if assert.NoError(t, err) && assert.NotNil(t, metricsAccount) {
 			defer underTest.DeleteMetricsAccount(int64(metricsAccount.Id))
 			time.Sleep(time.Second * 2)
-			// Update the plan_uts field without changing the account_name
 			createMetricsAccount.PlanUts = new(int32)
 			*createMetricsAccount.PlanUts = 200
 			err = underTest.UpdateMetricsAccount(int64(metricsAccount.Id), createMetricsAccount)
-			assert.Error(t, err)
-			// Check if the error message is as expected
-			assert.Contains(t, err.Error(), "Sub account with name (TEST_AUTOMATION_ACCOUNT) already exists on account")
-		}
-	}
-}
+			assert.NoError(t, err)
 
-func TestIntegrationMetricsAccount_UpdateMetricsAccountWithAuthorizedAccounts(t *testing.T) {
-	underTest, email, err := setupMetricsAccountsIntegrationTest()
-
-	if assert.NoError(t, err) {
-		createMetricsAccount := getCreateOrUpdateMetricsAccount(email)
-		// Add an authorized account
-		createMetricsAccount.AuthorizedAccountsIds = append(createMetricsAccount.AuthorizedAccountsIds, 123456)
-		metricsAccount, err := underTest.CreateMetricsAccount(createMetricsAccount)
-		if assert.NoError(t, err) && assert.NotNil(t, metricsAccount) {
-			defer underTest.DeleteMetricsAccount(int64(metricsAccount.Id))
-			time.Sleep(time.Second * 2)
-			// Update the plan_uts field
-			createMetricsAccount.PlanUts = new(int32)
-			*createMetricsAccount.PlanUts = 200
-			err = underTest.UpdateMetricsAccount(int64(metricsAccount.Id), createMetricsAccount)
-			assert.Error(t, err)
-			// Check if the error message is as expected
-			assert.Contains(t, err.Error(), "Sub account is not found for the owner account")
 		}
 	}
 }

--- a/metrics_accounts/metrics_account_update_test.go
+++ b/metrics_accounts/metrics_account_update_test.go
@@ -19,7 +19,16 @@ func TestMetricsAccount_UpdateValidMetricsAccount(t *testing.T) {
 	metricsAccountId := int64(1234567)
 
 	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
+		if r.Method == http.MethodGet {
+			metricsAccount := &metrics_accounts.MetricsAccount{
+				AccountName: "testAccount",
+				Id:          int32(metricsAccountId),
+				PlanUts:     100,
+			}
+			jsonBytes, _ := json.Marshal(metricsAccount)
+			w.Write(jsonBytes)
+			return
+		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
 		jsonBytes, _ := ioutil.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount
@@ -42,7 +51,16 @@ func TestMetricsAccount_UpdateOnlySomeParamsCorrectly(t *testing.T) {
 	metricsAccountId := int64(1234567)
 
 	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
+		if r.Method == http.MethodGet {
+			metricsAccount := &metrics_accounts.MetricsAccount{
+				AccountName: "testAccount",
+				Id:          int32(metricsAccountId),
+				PlanUts:     100,
+			}
+			jsonBytes, _ := json.Marshal(metricsAccount)
+			w.Write(jsonBytes)
+			return
+		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
 		jsonBytes, _ := ioutil.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount
@@ -66,7 +84,16 @@ func TestMetricsAccount_UpdateMetricsAccountIdNotFound(t *testing.T) {
 	metricsAccountId := int64(1234567)
 
 	mux.HandleFunc("/v1/account-management/metrics-accounts/", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
+		if r.Method == http.MethodGet {
+			metricsAccount := &metrics_accounts.MetricsAccount{
+				AccountName: "testAccount",
+				Id:          int32(metricsAccountId),
+				PlanUts:     100,
+			}
+			jsonBytes, _ := json.Marshal(metricsAccount)
+			w.Write(jsonBytes)
+			return
+		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
 		jsonBytes, _ := ioutil.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount


### PR DESCRIPTION
- Related to https://github.com/logzio/terraform-provider-logzio/issues/192
- Validate account existence before updating and set an empty account name If the name did not change
- Added Integration tests `TestIntegrationMetricsAccount_UpdateMetricsAccountPlanUts`