### PR TITLE
[Release] Grafana 10 changes following provider testing

### DIFF
--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -36,6 +36,6 @@ jobs:
           go-version: 1.24
       - name: Test
         # We exclude kibana_objects tests
-        run: |
-          go test $(go list ./... | grep -v kibana_objects | grep -v grafana_folders)
-          go test -parallel 1 ./grafana_folders
+        run: go test $(go list ./... | grep -v kibana_objects | grep -v grafana_folders)
+      - name: Test grafana folders
+        run: go test -parallel 1 ./grafana_folders

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,6 @@ jobs:
         go get golang.org/x/tools/cmd/cover
         go get github.com/mattn/goveralls
     - name: Test
-      run: go test -v -race ./... -covermode=atomic -coverprofile=coverage.out
+      run: |
+        go test -v -race $(go list ./... | grep -v grafana_folders) -covermode=atomic -coverprofile=coverage.out
+        go test -parallel 1 ./grafana_folders

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,6 @@ jobs:
         go get golang.org/x/tools/cmd/cover
         go get github.com/mattn/goveralls
     - name: Test
-      run: |
-        go test -v -race $(go list ./... | grep -v grafana_folders) -covermode=atomic -coverprofile=coverage.out
-        go test -parallel 1 ./grafana_folders
+      run: go test -v -race $(go list ./... | grep -v grafana_folders) -covermode=atomic -coverprofile=coverage.out
+    - name: Test grafana folders
+      run: go test -v -parallel 1 ./grafana_folders -covermode=atomic -coverprofile=coverage.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- next version -->
 
+## v1.23.1
+- Grafana Alerts API `ExecErrState` is no longer configurable as of Grafana 10
+- Add new Microsoft Teams Workflows Contact Point
+
 ## v1.23.0
 - Upgrade to Go 1.24.
 - Upgrade Grafana API to match Grafana 10.

--- a/grafana_alerts/client_grafana_alert.go
+++ b/grafana_alerts/client_grafana_alert.go
@@ -37,9 +37,9 @@ type GrafanaAlertRule struct {
 	Annotations  map[string]string    `json:"annotations,omitempty"`
 	Condition    string               `json:"condition"`    // Required
 	Data         []*GrafanaAlertQuery `json:"data"`         // Required
-	ExecErrState ExecErrState         `json:"execErrState"` // Required
+	ExecErrState ExecErrState         `json:"execErrState"`
 	FolderUID    string               `json:"folderUID"`    // Required
-	For          string               `json:"for"`          // Required, representing nanoseconds
+	For          string               `json:"for"`          // Required
 	Id           int64                `json:"id,omitempty"`
 	Labels       map[string]string    `json:"labels,omitempty"`
 	NoDataState  NoDataState          `json:"noDataState"` // Required
@@ -87,10 +87,6 @@ func validateGrafanaAlertRuleCreateUpdate(payload GrafanaAlertRule, isUpdate boo
 
 	if payload.Data == nil || len(payload.Data) == 0 {
 		return fmt.Errorf("Field data must be set!")
-	}
-
-	if len(payload.ExecErrState) == 0 {
-		return fmt.Errorf("Field execErrState must be set!")
 	}
 
 	if len(payload.FolderUID) == 0 {

--- a/grafana_alerts/client_grafana_alert.go
+++ b/grafana_alerts/client_grafana_alert.go
@@ -35,11 +35,11 @@ type GrafanaAlertClient struct {
 
 type GrafanaAlertRule struct {
 	Annotations  map[string]string    `json:"annotations,omitempty"`
-	Condition    string               `json:"condition"`    // Required
-	Data         []*GrafanaAlertQuery `json:"data"`         // Required
+	Condition    string               `json:"condition"` // Required
+	Data         []*GrafanaAlertQuery `json:"data"`      // Required
 	ExecErrState ExecErrState         `json:"execErrState"`
-	FolderUID    string               `json:"folderUID"`    // Required
-	For          string               `json:"for"`          // Required
+	FolderUID    string               `json:"folderUID"` // Required
+	For          string               `json:"for"`       // Required
 	Id           int64                `json:"id,omitempty"`
 	Labels       map[string]string    `json:"labels,omitempty"`
 	NoDataState  NoDataState          `json:"noDataState"` // Required

--- a/grafana_contact_points/client_grafana_contact_point.go
+++ b/grafana_contact_points/client_grafana_contact_point.go
@@ -16,14 +16,15 @@ const (
 
 	grafanaContactPointResourceName = "grafana contact point"
 
-	GrafanaContactPointTypeEmail          ContactPointType = "email"
-	GrafanaContactPointTypeGoogleChat     ContactPointType = "googlechat"
-	GrafanaContactPointTypeOpsgenie       ContactPointType = "opsgenie"
-	GrafanaContactPointTypePagerduty      ContactPointType = "pagerduty"
-	GrafanaContactPointTypeSlack          ContactPointType = "slack"
-	GrafanaContactPointTypeMicrosoftTeams ContactPointType = "teams"
-	GrafanaContactPointTypeVictorps       ContactPointType = "victorops"
-	GrafanaContactPointTypeWebhook        ContactPointType = "webhook"
+	GrafanaContactPointTypeEmail                   ContactPointType = "email"
+	GrafanaContactPointTypeGoogleChat              ContactPointType = "googlechat"
+	GrafanaContactPointTypeOpsgenie                ContactPointType = "opsgenie"
+	GrafanaContactPointTypePagerduty               ContactPointType = "pagerduty"
+	GrafanaContactPointTypeSlack                   ContactPointType = "slack"
+	GrafanaContactPointTypeMicrosoftTeams          ContactPointType = "teams"
+	GrafanaContactPointTypeVictorps                ContactPointType = "victorops"
+	GrafanaContactPointTypeWebhook                 ContactPointType = "webhook"
+	GrafanaContactPointTypeMicrosoftTeamsWorkflows ContactPointType = "teams_workflows"
 )
 
 type GrafanaContactPointClient struct {
@@ -70,5 +71,6 @@ func GetSupportedContactPointTypes() []ContactPointType {
 		GrafanaContactPointTypeMicrosoftTeams,
 		GrafanaContactPointTypeVictorps,
 		GrafanaContactPointTypeWebhook,
+		GrafanaContactPointTypeMicrosoftTeamsWorkflows,
 	}
 }


### PR DESCRIPTION
## Description 

- Add support for Microsoft Workflows contact point
- `ExecErrState` is no longer configurable as of Grafana 10, removed config that forced setting it
- Split Grafana folder tests from parallel tests to avoid flakiness caused by concurrent modifications

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
