### PR TITLE
[Release] Add new sub accounts fields for warm retention `v1.24.0`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     env:
       LOGZIO_API_TOKEN: ${{ secrets.LOGZIO_API_TOKEN }}
+      LOGZIO_WARM_API_TOKEN: ${{ secrets.LOGZIO_WARM_API_TOKEN }}
       LOGZIO_EMAIL: ${{ secrets.LOGZIO_EMAIL }}
       LOGZIO_ACCOUNT_ID: ${{ secrets.LOGZIO_ACCOUNT_ID }}
       S3_PATH: ${{ secrets.S3_PATH }}
@@ -35,6 +36,8 @@ jobs:
       run: |
         go get golang.org/x/tools/cmd/cover
         go get github.com/mattn/goveralls
+        go mod tidy
+        go mod download
     - name: Test
       run: go test -v -race $(go list ./... | grep -v grafana_folders) -covermode=atomic -coverprofile=coverage.out
     - name: Test grafana folders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 <!-- next version -->
 
 ## v1.24.0
-- Add Warm Retention options in `sub_accounts`.
+- Support Warm Retention settings in `sub_accounts`.
+  - Add `snapSearchRetentionDays` to create and update requests
+  - Add new fields to sub account data: `IsCapped`, `SharedGB`, `TotalTimeBasedDailyGB`, `IsOwner`.
 
 ## v1.23.2
 - Grafana Contact Point `teams` now refers to Microsoft Teams Workflows Contact Point. The old `teams` endpoint was deprecated in grafana 10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <!-- next version -->
 
+## v1.24.0
+- Add Warm Retention options in `sub_accounts`.
+
 ## v1.23.2
 - Grafana Contact Point `teams` now refers to Microsoft Teams Workflows Contact Point. The old `teams` endpoint was deprecated in grafana 10.
 

--- a/alerts_v2/alerts_v2_test.go
+++ b/alerts_v2/alerts_v2_test.go
@@ -3,9 +3,9 @@ package alerts_v2_test
 import (
 	"github.com/logzio/logzio_terraform_client/alerts_v2"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"testing"
 )
@@ -16,7 +16,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/alerts_v2/create_alerts_v2_test.go
+++ b/alerts_v2/create_alerts_v2_test.go
@@ -3,7 +3,7 @@ package alerts_v2_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -19,7 +19,7 @@ func TestAlertsV2_CreateAlert(t *testing.T) {
 		mux.HandleFunc("/v2/alerts", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
 
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target alerts_v2.CreateAlertType
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NotNil(t, target)

--- a/alerts_v2/update_alerts_v2_test.go
+++ b/alerts_v2/update_alerts_v2_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/alerts_v2"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -21,7 +21,7 @@ func TestAlertsV2_UpdateAlert(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(alertId, 10))
 
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target alerts_v2.CreateAlertType
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotNil(t, target)

--- a/archive_logs/archive_logs_setup_test.go
+++ b/archive_logs/archive_logs_setup_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"github.com/stretchr/testify/assert"
-	"io/"
+	"io"
 	"net/http"
 	"testing"
 )

--- a/archive_logs/archive_logs_setup_test.go
+++ b/archive_logs/archive_logs_setup_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io/"
 	"net/http"
 	"testing"
 )
@@ -18,7 +18,7 @@ func TestArchiveLogs_SetupArchiveS3Keys(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestArchiveLogs_SetupArchiveS3Iam(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestArchiveLogs_SetupArchiveBlob(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/archive_logs/archive_logs_test.go
+++ b/archive_logs/archive_logs_test.go
@@ -3,7 +3,6 @@ package archive_logs_test
 import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 )
@@ -28,7 +27,7 @@ func setupArchiveLogsTest() (*archive_logs.ArchiveLogsClient, func(), error) {
 }
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/archive_logs/archive_logs_test.go
+++ b/archive_logs/archive_logs_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 var (

--- a/archive_logs/archive_logs_update_test.go
+++ b/archive_logs/archive_logs_update_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"

--- a/archive_logs/archive_logs_update_test.go
+++ b/archive_logs/archive_logs_update_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"testing"
@@ -20,7 +19,7 @@ func TestArchiveLogs_UpdateArchiveS3(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -57,7 +56,7 @@ func TestArchiveLogs_UpdateArchiveBlob(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -99,7 +98,7 @@ func TestArchiveLogs_UpdateArchiveIdNotFound(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(archiveApiBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target archive_logs.CreateOrUpdateArchiving
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/authentication_groups/authentication_groups_post_test.go
+++ b/authentication_groups/authentication_groups_post_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/authentication_groups"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"testing"
 )

--- a/authentication_groups/authentication_groups_post_test.go
+++ b/authentication_groups/authentication_groups_post_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/authentication_groups"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -17,7 +16,7 @@ func TestAuthenticationGroups_Post(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(authGroupsApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target []authentication_groups.AuthenticationGroup
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/authentication_groups/authentication_groups_test.go
+++ b/authentication_groups/authentication_groups_test.go
@@ -3,9 +3,9 @@ package authentication_groups_test
 import (
 	"github.com/logzio/logzio_terraform_client/authentication_groups"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 var (
@@ -38,7 +38,7 @@ func setupAuthenticationGroupsIntegrationTest() (*authentication_groups.Authenti
 }
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/drop_filters/create_drop_filters_test.go
+++ b/drop_filters/create_drop_filters_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/drop_filters"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestDropFilters_CreateDropFilter(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/drop-filters", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target drop_filters.CreateDropFilter
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/drop_filters/drop_filter_test.go
+++ b/drop_filters/drop_filter_test.go
@@ -3,9 +3,9 @@ package drop_filters_test
 import (
 	"github.com/logzio/logzio_terraform_client/drop_filters"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/endpoints/endpoints_bigpanda_test.go
+++ b/endpoints/endpoints_bigpanda_test.go
@@ -1,11 +1,12 @@
 package endpoints_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +19,7 @@ func TestEndpoints_CreateEndpointBigPanda(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/big-panda", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -45,7 +46,7 @@ func TestEndpoints_CreateEndpointBigPandaApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/big-panda", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -73,7 +74,7 @@ func TestEndpoints_UpdateEndpointBigPanda(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/big-panda/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
 		assert.Equal(t, http.MethodPut, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_bigpanda_test.go
+++ b/endpoints/endpoints_bigpanda_test.go
@@ -1,7 +1,6 @@
 package endpoints_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"

--- a/endpoints/endpoints_custom_test.go
+++ b/endpoints/endpoints_custom_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateCustomEndpoint(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/custom", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestEndpoints_CreateCustomEndpointApiFail(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/custom", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -84,7 +84,7 @@ func TestEndpoints_UpdateCustomEndpoint(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/custom/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)

--- a/endpoints/endpoints_datadog_test.go
+++ b/endpoints/endpoints_datadog_test.go
@@ -1,11 +1,11 @@
 package endpoints_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"

--- a/endpoints/endpoints_datadog_test.go
+++ b/endpoints/endpoints_datadog_test.go
@@ -1,11 +1,11 @@
 package endpoints_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateEndpointDataDog(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/data-dog", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -43,7 +43,7 @@ func TestEndpoints_CreateEndpointDataDogApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/data-dog", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -69,7 +69,7 @@ func TestEndpoints_UpdateEndpointDataDog(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/data-dog/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_microsoftteams_test.go
+++ b/endpoints/endpoints_microsoftteams_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateEndpointMicrosoftTeams(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/microsoft-teams", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -43,7 +43,7 @@ func TestEndpoints_CreateEndpointMicrosoftTeamsApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/microsoft-teams", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -69,7 +69,7 @@ func TestEndpoints_UpdateEndpointMicrosoftTeams(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/microsoft-teams/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_opsgenie_test.go
+++ b/endpoints/endpoints_opsgenie_test.go
@@ -1,7 +1,6 @@
 package endpoints_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"

--- a/endpoints/endpoints_opsgenie_test.go
+++ b/endpoints/endpoints_opsgenie_test.go
@@ -1,11 +1,12 @@
 package endpoints_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +19,7 @@ func TestEndpoints_CreateEndpointOpsGenie(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/ops-genie", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -43,7 +44,7 @@ func TestEndpoints_CreateEndpointOpsGenieApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/ops-genie", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -69,7 +70,7 @@ func TestEndpoints_UpdateEndpointOpsGenie(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/ops-genie/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_pagerduty_test.go
+++ b/endpoints/endpoints_pagerduty_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateEndpointPagerDuty(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/pager-duty", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -43,7 +43,7 @@ func TestEndpoints_CreateEndpointPagerDutyApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/pager-duty", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -69,7 +69,7 @@ func TestEndpoints_UpdateEndpointPagerDuty(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/pager-duty/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_servicenow_test.go
+++ b/endpoints/endpoints_servicenow_test.go
@@ -1,7 +1,6 @@
 package endpoints_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"

--- a/endpoints/endpoints_servicenow_test.go
+++ b/endpoints/endpoints_servicenow_test.go
@@ -1,11 +1,12 @@
 package endpoints_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +19,7 @@ func TestEndpoints_CreateEndpointServiceNow(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/service-now", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -47,7 +48,7 @@ func TestEndpoints_CreateEndpointServiceNowApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/service-now", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -77,7 +78,7 @@ func TestEndpoints_UpdateEndpointServiceNow(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/service-now/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_slack_test.go
+++ b/endpoints/endpoints_slack_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateEndpointSlack(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/slack", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -43,7 +43,7 @@ func TestEndpoints_CreateEndpointSlackApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/slack", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -69,7 +69,7 @@ func TestEndpoints_UpdateEndpointSlack(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/slack/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -3,9 +3,9 @@ package endpoints_test
 import (
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -20,7 +20,7 @@ const (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/endpoints/endpoints_victorops_test.go
+++ b/endpoints/endpoints_victorops_test.go
@@ -1,11 +1,11 @@
 package endpoints_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +18,7 @@ func TestEndpoints_CreateEndpointVictorOps(t *testing.T) {
 
 	mux.HandleFunc("/v1/endpoints/victorops", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -47,7 +47,7 @@ func TestEndpoints_CreateEndpointVictorOpsApiFail(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/victorops", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		assert.Equal(t, http.MethodPost, r.Method)
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))
@@ -77,7 +77,7 @@ func TestEndpoints_UpdateEndpointVictorOps(t *testing.T) {
 	mux.HandleFunc("/v1/endpoints/victorops/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(endpointId, 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target endpoints.CreateOrUpdateEndpoint
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NotZero(t, len(target.Title))

--- a/endpoints/endpoints_victorops_test.go
+++ b/endpoints/endpoints_victorops_test.go
@@ -1,11 +1,11 @@
 package endpoints_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/endpoints"
 	"github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"

--- a/kibana_objects/export_kibana_objects_test.go
+++ b/kibana_objects/export_kibana_objects_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/kibana_objects"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestKibanaObjects_ExportKibanaObject(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(exportPath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target kibana_objects.KibanaObjectExportRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestKibanaObjects_ExportKibanaObjectApiFail(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(exportPath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target kibana_objects.KibanaObjectExportRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/kibana_objects/import_kibana_object_test.go
+++ b/kibana_objects/import_kibana_object_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/kibana_objects"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestKibanaObjects_ImportKibanaObject(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(importPath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target kibana_objects.KibanaObjectImportRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -46,7 +46,7 @@ func TestKibanaObjects_ImportKibanaObjectApiFail(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(importPath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target kibana_objects.KibanaObjectImportRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/kibana_objects/kibana_objects_test.go
+++ b/kibana_objects/kibana_objects_test.go
@@ -3,9 +3,12 @@ package kibana_objects_test
 import (
 	"encoding/json"
 	"github.com/logzio/logzio_terraform_client/test_utils"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/logzio/logzio_terraform_client/kibana_objects"
 )
@@ -54,6 +57,7 @@ func getExportRequest() kibana_objects.KibanaObjectExportRequest {
 }
 
 func getImportRequest() (kibana_objects.KibanaObjectImportRequest, error) {
+	randomSuffix := getRandomId()
 	source := `{
         "search": {
           "columns": [
@@ -63,15 +67,15 @@ func getImportRequest() (kibana_objects.KibanaObjectImportRequest, error) {
             "@timestamp",
             "desc"
           ],
-          "id": "tf-client-test",
-          "title": "tf-client-test",
+          "id": "tf-client-test-` + randomSuffix + `",
+          "title": "tf-client-test-` + randomSuffix + `",
           "version": 1,
           "kibanaSavedObjectMeta": {
             "searchSourceJSON": "{\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[],\"query\":{\"query\":\"type: tf-client-test\",\"language\":\"lucene\"},\"source\":{\"excludes\":[]},\"highlightAll\":true,\"version\":true,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
           }
         },
         "type": "search",
-        "id": "tf-client-test"
+        "id": "tf-client-test-` + randomSuffix + `"
       }`
 	var sourceObj map[string]interface{}
 	err := json.Unmarshal([]byte(source), &sourceObj)
@@ -87,4 +91,9 @@ func getImportRequest() (kibana_objects.KibanaObjectImportRequest, error) {
 		KibanaVersion: "7.2.1",
 		Hits:          []map[string]interface{}{hitsObj},
 	}, err
+}
+
+func getRandomId() string {
+	rand.New(rand.NewSource(time.Now().UnixNano()))
+	return strconv.Itoa(rand.Intn(10000))
 }

--- a/kibana_objects/kibana_objects_test.go
+++ b/kibana_objects/kibana_objects_test.go
@@ -3,9 +3,9 @@ package kibana_objects_test
 import (
 	"encoding/json"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	"github.com/logzio/logzio_terraform_client/kibana_objects"
 )
@@ -21,7 +21,7 @@ const (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/kibana_objects/kibana_objects_test.go
+++ b/kibana_objects/kibana_objects_test.go
@@ -83,7 +83,7 @@ func getImportRequest() (kibana_objects.KibanaObjectImportRequest, error) {
 	hitsObj := map[string]interface{}{
 		"_index":  "logzioCustomerIndex*",
 		"_type":   "_doc",
-		"_id":     "search:tf-client-test",
+		"_id":     "search:tf-client-test-" + randomSuffix,
 		"_source": sourceObj,
 	}
 

--- a/log_shipping_tokens/create_log_shipping_tokens_test.go
+++ b/log_shipping_tokens/create_log_shipping_tokens_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/log_shipping_tokens"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestLogShippingTokens_CreateLogShippingToken(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/tokens", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target log_shipping_tokens.CreateLogShippingToken
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/log_shipping_tokens/log_shipping_tokens_test.go
+++ b/log_shipping_tokens/log_shipping_tokens_test.go
@@ -3,9 +3,9 @@ package log_shipping_tokens_test
 import (
 	"github.com/logzio/logzio_terraform_client/log_shipping_tokens"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 )
 
@@ -42,7 +42,7 @@ func setupLogShippingTokenTest() (*log_shipping_tokens.LogShippingTokensClient, 
 }
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/log_shipping_tokens/retrieve_log_shipping_tokens_test.go
+++ b/log_shipping_tokens/retrieve_log_shipping_tokens_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/log_shipping_tokens"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -18,7 +18,7 @@ func TestLogShippingTokens_RetrieveLogShippingTokens(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/tokens/search", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target log_shipping_tokens.RetrieveLogShippingTokensRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -46,7 +46,7 @@ func TestLogShippingTokens_RetrieveLogShippingTokensAPIFailed(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/tokens/search", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target log_shipping_tokens.RetrieveLogShippingTokensRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/log_shipping_tokens/update_log_shipping_tokens_test.go
+++ b/log_shipping_tokens/update_log_shipping_tokens_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/log_shipping_tokens"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -18,7 +18,7 @@ func TestLogShippingTokens_UpdateLogShippingToken(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/tokens/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target log_shipping_tokens.UpdateLogShippingToken
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestLogShippingTokens_UpdateLogShippingTokenIdNotFound(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/tokens/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target log_shipping_tokens.UpdateLogShippingToken
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/metrics_accounts/metrics_account_create_test.go
+++ b/metrics_accounts/metrics_account_create_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/metrics_accounts"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestMetricsAccount_CreateValidMetricsAccount(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target metrics_accounts.CreateOrUpdateMetricsAccount
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestMetricsAccount_CreateMetricsAccountNoAccountName(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/account-management/metrics-accounts", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target metrics_accounts.CreateOrUpdateMetricsAccount
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/metrics_accounts/metrics_account_test.go
+++ b/metrics_accounts/metrics_account_test.go
@@ -3,9 +3,9 @@ package metrics_accounts_test
 import (
 	"github.com/logzio/logzio_terraform_client/metrics_accounts"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/metrics_accounts/metrics_account_update_test.go
+++ b/metrics_accounts/metrics_account_update_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/metrics_accounts"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -30,7 +30,7 @@ func TestMetricsAccount_UpdateValidMetricsAccount(t *testing.T) {
 			return
 		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -62,7 +62,7 @@ func TestMetricsAccount_UpdateOnlySomeParamsCorrectly(t *testing.T) {
 			return
 		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -95,7 +95,7 @@ func TestMetricsAccount_UpdateMetricsAccountIdNotFound(t *testing.T) {
 			return
 		}
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(metricsAccountId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target metrics_accounts.CreateOrUpdateMetricsAccount
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)

--- a/restore_logs/restore_logs_initiate_test.go
+++ b/restore_logs/restore_logs_initiate_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/restore_logs"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestRestoreLogs_InitiateRestore(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(restoreApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target restore_logs.InitiateRestore
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestRestoreLogs_InitiateRestoreApiFail(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(restoreApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target restore_logs.InitiateRestore
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/restore_logs/restore_logs_test.go
+++ b/restore_logs/restore_logs_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/logzio/logzio_terraform_client/archive_logs"
 	"github.com/logzio/logzio_terraform_client/restore_logs"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +24,9 @@ const (
 	restoreApiBasePath = "/archive/restore"
 )
 
-/* setupRestoreLogsIntegrationTest sets up the resources that are needed to test the Restore API.
+/*
+	setupRestoreLogsIntegrationTest sets up the resources that are needed to test the Restore API.
+
 The function retrieves the api token, base url, and creates a new restore logs client.
 To initiate a restore operation, an active archive needs to be connected to the Logz.io account, so the function also
 creates an archive, and retrieves the function that deletes it.
@@ -112,7 +113,7 @@ func setupRestoreLogsTest() (*restore_logs.RestoreClient, func(), error) {
 }
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/s3_fetcher/s3_fetcher_create_test.go
+++ b/s3_fetcher/s3_fetcher_create_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/s3_fetcher"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -17,7 +17,7 @@ func TestS3Fetcher_CreateS3FetcherKeys(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/s3-buckets", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target s3_fetcher.S3FetcherRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestS3Fetcher_CreateS3FetcherArn(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/s3-buckets", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target s3_fetcher.S3FetcherRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestS3Fetcher_CreateS3FetcherInternalServerError(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc("/v1/log-shipping/s3-buckets", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target s3_fetcher.S3FetcherRequest
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/s3_fetcher/s3_fetcher_test.go
+++ b/s3_fetcher/s3_fetcher_test.go
@@ -3,7 +3,6 @@ package s3_fetcher_test
 import (
 	"github.com/logzio/logzio_terraform_client/s3_fetcher"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,7 +23,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/s3_fetcher/s3_fetcher_update_test.go
+++ b/s3_fetcher/s3_fetcher_update_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"github.com/logzio/logzio_terraform_client/s3_fetcher"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -20,7 +20,7 @@ func TestS3Fetcher_UpdateFetcher(t *testing.T) {
 	mux.HandleFunc("/v1/log-shipping/s3-buckets/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(fetcherId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target s3_fetcher.S3FetcherRequest
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -42,7 +42,7 @@ func TestS3Fetcher_UpdateFetcherInternalServerError(t *testing.T) {
 	mux.HandleFunc("/v1/log-shipping/s3-buckets/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(fetcherId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target s3_fetcher.S3FetcherRequest
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestS3Fetcher_UpdateFetcherNoPermission(t *testing.T) {
 	mux.HandleFunc("/v1/log-shipping/s3-buckets/", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(fetcherId), 10))
-		jsonBytes, _ := ioutil.ReadAll(r.Body)
+		jsonBytes, _ := io.ReadAll(r.Body)
 		var target s3_fetcher.S3FetcherRequest
 		err = json.Unmarshal(jsonBytes, &target)
 		assert.NoError(t, err)

--- a/sub_accounts/client_sub_account.go
+++ b/sub_accounts/client_sub_account.go
@@ -7,15 +7,14 @@ import (
 )
 
 const (
-	subAccountServiceEndpoint        = "%s/v1/account-management/time-based-accounts"
-	loggerName                       = "logzio-client"
-	operationGetSubAccount           = "GetSubAccount"
-	operationDeleteSubAccount        = "DeleteSubAccount"
-	operationGetDetailedSubAccount   = "GetDetailedSubAccount"
-	operationListSubAccounts         = "ListSubAccounts"
-	operationListDetailedSubAccounts = "ListDetailedSubAccounts"
-	operationUpdateSubAccount        = "UpdateSubAccount"
-	operationCreateSubAccount        = "CreateSubAccount"
+	subAccountServiceEndpoint      = "%s/v1/account-management/time-based-accounts"
+	loggerName                     = "logzio-client"
+	operationGetSubAccount         = "GetSubAccount"
+	operationDeleteSubAccount      = "DeleteSubAccount"
+	operationGetDetailedSubAccount = "GetDetailedSubAccount"
+	operationListSubAccounts       = "ListSubAccounts"
+	operationUpdateSubAccount      = "UpdateSubAccount"
+	operationCreateSubAccount      = "CreateSubAccount"
 
 	subAccountResourceName = "sub account"
 )
@@ -26,17 +25,18 @@ type SubAccountClient struct {
 }
 
 type CreateOrUpdateSubAccount struct {
-	Email                  string                                   `json:"email,omitempty"`
-	AccountName            string                                   `json:"accountName"`
-	Flexible               string                                   `json:"isFlexible,omitempty"` // boolean
-	ReservedDailyGB        *float32                                 `json:"reservedDailyGB,omitempty"`
-	MaxDailyGB             *float32                                 `json:"maxDailyGB,omitempty"`
-	RetentionDays          int32                                    `json:"retentionDays"`
-	Searchable             string                                   `json:"searchable,omitempty"` // boolean
-	Accessible             string                                   `json:"accessible,omitempty"` // boolean
-	SharingObjectsAccounts []int32                                  `json:"sharingObjectsAccounts"`
-	DocSizeSetting         string                                   `json:"docSizeSetting"` // boolean
-	UtilizationSettings    AccountUtilizationSettingsCreateOrUpdate `json:"utilizationSettings"`
+	Email                   string                                   `json:"email,omitempty"`
+	AccountName             string                                   `json:"accountName"`
+	Flexible                string                                   `json:"isFlexible,omitempty"` // boolean
+	ReservedDailyGB         *float32                                 `json:"reservedDailyGB,omitempty"`
+	MaxDailyGB              *float32                                 `json:"maxDailyGB,omitempty"`
+	RetentionDays           int32                                    `json:"retentionDays"`
+	Searchable              string                                   `json:"searchable,omitempty"` // boolean
+	Accessible              string                                   `json:"accessible,omitempty"` // boolean
+	SharingObjectsAccounts  []int32                                  `json:"sharingObjectsAccounts"`
+	DocSizeSetting          string                                   `json:"docSizeSetting"` // boolean
+	UtilizationSettings     AccountUtilizationSettingsCreateOrUpdate `json:"utilizationSettings"`
+	SnapSearchRetentionDays *int32                                   `json:"snapSearchRetentionDays,omitempty"`
 }
 
 type AccountUtilizationSettingsCreateOrUpdate struct {
@@ -50,18 +50,23 @@ type AccountUtilizationSettings struct {
 }
 
 type SubAccount struct {
-	AccountId              int32                      `json:"accountId"`
-	Email                  string                     `json:"email"`
-	AccountName            string                     `json:"accountName"`
-	Flexible               bool                       `json:"isFlexible"`
-	ReservedDailyGB        float32                    `json:"reservedDailyGB"`
-	MaxDailyGB             float32                    `json:"maxDailyGB"`
-	RetentionDays          int32                      `json:"retentionDays"`
-	Searchable             bool                       `json:"searchable"`
-	Accessible             bool                       `json:"accessible"`
-	DocSizeSetting         bool                       `json:"docSizeSetting"`
-	SharingObjectsAccounts []SharingAccount           `json:"sharingObjectsAccounts"`
-	UtilizationSettings    AccountUtilizationSettings `json:"utilizationSettings"`
+	AccountId               int32                      `json:"accountId"`
+	Email                   string                     `json:"email"`
+	AccountName             string                     `json:"accountName"`
+	Flexible                bool                       `json:"isFlexible"`
+	ReservedDailyGB         float32                    `json:"reservedDailyGB"`
+	MaxDailyGB              float32                    `json:"maxDailyGB"`
+	RetentionDays           int32                      `json:"retentionDays"`
+	Searchable              bool                       `json:"searchable"`
+	Accessible              bool                       `json:"accessible"`
+	DocSizeSetting          bool                       `json:"docSizeSetting"`
+	SharingObjectsAccounts  []SharingAccount           `json:"sharingObjectsAccounts"`
+	UtilizationSettings     AccountUtilizationSettings `json:"utilizationSettings"`
+	SnapSearchRetentionDays int32                      `json:"snapSearchRetentionDays"`
+	IsCapped                bool                       `json:"isCapped"`
+	SharedGB                float32                    `json:"sharedGB"`
+	TotalTimeBasedDailyGB   float32                    `json:"totalTimeBasedDailyGB"`
+	IsOwner                 bool                       `json:"isOwner"`
 }
 
 type SharingAccount struct {
@@ -70,12 +75,14 @@ type SharingAccount struct {
 }
 
 type DetailedSubAccount struct {
-	SubAccountRelation     SubAccountRelationObject   `json:"subAccountRelation"`
-	Account                AccountView                `json:"account"`
-	SharingObjectsAccounts []AccountView              `json:"sharingObjectsAccounts"`
-	UtilizationSettings    AccountUtilizationSettings `json:"utilizationSettings"`
-	DailyUsagesList        DailyUsagesListObject      `json:"dailyUsagesList"`
-	DocSizeSetting         bool                       `json:"docSizeSetting"`
+	SubAccountRelation      SubAccountRelationObject   `json:"subAccountRelation"`
+	Account                 AccountView                `json:"account"`
+	SharingObjectsAccounts  []AccountView              `json:"sharingObjectsAccounts"`
+	UtilizationSettings     AccountUtilizationSettings `json:"utilizationSettings"`
+	DailyUsagesList         DailyUsagesListObject      `json:"dailyUsagesList"`
+	DocSizeSetting          bool                       `json:"docSizeSetting"`
+	SnapSearchRetentionDays int32                      `json:"snapSearchRetentionDays"`
+	IsCapped                bool                       `json:"isCapped"`
 }
 
 type SubAccountRelationObject struct {

--- a/sub_accounts/client_sub_account_create.go
+++ b/sub_accounts/client_sub_account_create.go
@@ -95,5 +95,15 @@ func validateCreateSubAccount(createSubAccount CreateOrUpdateSubAccount) error {
 			return fmt.Errorf("utilizationEnabled field is not set to boolean value")
 		}
 	}
+
+	if createSubAccount.SnapSearchRetentionDays != nil {
+		if *createSubAccount.SnapSearchRetentionDays < 1 {
+			return fmt.Errorf("snapSearchRetentionDays should be >= 1")
+		}
+		if createSubAccount.RetentionDays < 4 {
+			return fmt.Errorf("SnapSearchRetentionDays cannot be set if retentionDays is less than 4")
+		}
+	}
+	
 	return nil
 }

--- a/sub_accounts/client_sub_account_update.go
+++ b/sub_accounts/client_sub_account_update.go
@@ -57,5 +57,9 @@ func validateUpdateSubAccount(updateSubAccount CreateOrUpdateSubAccount) error {
 		}
 	}
 
+	if updateSubAccount.SnapSearchRetentionDays != nil && *updateSubAccount.SnapSearchRetentionDays < 1 {
+		return fmt.Errorf("snapSearchRetentionDays should be >= 1")
+	}
+
 	return nil
 }

--- a/sub_accounts/sub_account_create_integration_test.go
+++ b/sub_accounts/sub_account_create_integration_test.go
@@ -160,3 +160,23 @@ func TestIntegrationSubAccount_CreateSubAccountNoRetention(t *testing.T) {
 		assert.Nil(t, subAccount)
 	}
 }
+
+func TestIntegrationSubAccount_CreateSubAccountWarmRetention(t *testing.T) {
+	underTest, email, err := setupSubAccountsWarmIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createSubAccount := getCreateOrUpdateSubAccount(email)
+		createSubAccount.AccountName = createSubAccount.AccountName + "_create"
+		createSubAccount.RetentionDays = 4
+		warmRetention := int32(2)
+		createSubAccount.SnapSearchRetentionDays = &warmRetention
+
+		subAccount, err := underTest.CreateSubAccount(createSubAccount)
+		if assert.NoError(t, err) && assert.NotNil(t, subAccount) {
+			time.Sleep(4 * time.Second)
+			defer underTest.DeleteSubAccount(int64(subAccount.AccountId))
+			assert.NotEmpty(t, subAccount.AccountToken)
+			assert.NotEmpty(t, subAccount.AccountId)
+		}
+	}
+}

--- a/sub_accounts/sub_account_test.go
+++ b/sub_accounts/sub_account_test.go
@@ -3,9 +3,9 @@ package sub_accounts_test
 import (
 	"github.com/logzio/logzio_terraform_client/sub_accounts"
 	"github.com/logzio/logzio_terraform_client/test_utils"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 )
 
@@ -15,7 +15,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}
@@ -34,12 +34,7 @@ func setupSubAccountsTest() (*sub_accounts.SubAccountClient, error, func()) {
 	}
 }
 
-func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, string, error) {
-	apiToken, err := test_utils.GetApiToken()
-	if err != nil {
-		return nil, "", err
-	}
-
+func setupSubAccountsIntegrationTestHandler(apiToken string) (*sub_accounts.SubAccountClient, string, error) {
 	email, err := test_utils.GetLogzioEmail()
 	if err != nil {
 		return nil, "", err
@@ -47,6 +42,24 @@ func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, string, 
 
 	underTest, err := sub_accounts.New(apiToken, test_utils.GetLogzIoBaseUrl())
 	return underTest, email, err
+}
+
+func setupSubAccountsIntegrationTest() (*sub_accounts.SubAccountClient, string, error) {
+	apiToken, err := test_utils.GetApiToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return setupSubAccountsIntegrationTestHandler(apiToken)
+}
+
+func setupSubAccountsWarmIntegrationTest() (*sub_accounts.SubAccountClient, string, error) {
+	apiToken, err := test_utils.GetWarmApiToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return setupSubAccountsIntegrationTestHandler(apiToken)
 }
 
 func getCreateOrUpdateSubAccount(email string) sub_accounts.CreateOrUpdateSubAccount {

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -10,6 +10,7 @@ import (
 const (
 	EnvLogzioBaseUrl             = "LOGZIO_BASE_URL"
 	EnvLogzioApiToken     string = "LOGZIO_API_TOKEN"
+	EnvLogzioWarmApiToken string = "LOGZIO_WARM_API_TOKEN"
 	EnvLogzioAccountId    string = "LOGZIO_ACCOUNT_ID"
 	LogzioBaseUrl         string = "https://api.logz.io"
 	EnvLogzioEmail        string = "LOGZIO_EMAIL"
@@ -33,6 +34,14 @@ func GetApiToken() (string, error) {
 		return apiToken, nil
 	}
 	return "", fmt.Errorf("%s env var not specified", EnvLogzioApiToken)
+}
+
+func GetWarmApiToken() (string, error) {
+	apiToken := os.Getenv(EnvLogzioWarmApiToken)
+	if len(apiToken) > 0 {
+		return apiToken, nil
+	}
+	return "", fmt.Errorf("%s env var not specified", EnvLogzioWarmApiToken)
 }
 
 func GetAccountId() (int64, error) {

--- a/users/user_create_test.go
+++ b/users/user_create_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/users"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -18,7 +18,7 @@ func TestUsers_CreateUser(t *testing.T) {
 		if assert.NoError(t, err) {
 			mux.HandleFunc(usersApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
-				jsonBytes, _ := ioutil.ReadAll(r.Body)
+				jsonBytes, _ := io.ReadAll(r.Body)
 				var target users.CreateUpdateUser
 				err = json.Unmarshal(jsonBytes, &target)
 				assert.NoError(t, err)
@@ -48,7 +48,7 @@ func TestUsers_CreateUserApiFail(t *testing.T) {
 		if assert.NoError(t, err) {
 			mux.HandleFunc(usersApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
-				jsonBytes, _ := ioutil.ReadAll(r.Body)
+				jsonBytes, _ := io.ReadAll(r.Body)
 				var target users.CreateUpdateUser
 				err = json.Unmarshal(jsonBytes, &target)
 				assert.NoError(t, err)
@@ -77,7 +77,7 @@ func TestUsers_CreateUserDuplicateUser(t *testing.T) {
 		if assert.NoError(t, err) {
 			mux.HandleFunc(usersApiBasePath, func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
-				jsonBytes, _ := ioutil.ReadAll(r.Body)
+				jsonBytes, _ := io.ReadAll(r.Body)
 				var target users.CreateUpdateUser
 				err = json.Unmarshal(jsonBytes, &target)
 				assert.NoError(t, err)

--- a/users/user_test.go
+++ b/users/user_test.go
@@ -3,9 +3,9 @@ package users_test
 import (
 	"github.com/logzio/logzio_terraform_client/test_utils"
 	"github.com/logzio/logzio_terraform_client/users"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 )
 
 const usersApiBasePath = "/v1/user-management"
@@ -16,7 +16,7 @@ var (
 )
 
 func fixture(path string) string {
-	b, err := ioutil.ReadFile("testdata/fixtures/" + path)
+	b, err := os.ReadFile("testdata/fixtures/" + path)
 	if err != nil {
 		panic(err)
 	}

--- a/users/user_update_test.go
+++ b/users/user_update_test.go
@@ -1,7 +1,6 @@
 package users_test
 
 import (
-	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/users"

--- a/users/user_update_test.go
+++ b/users/user_update_test.go
@@ -1,11 +1,12 @@
 package users_test
 
 import (
+	""
 	"encoding/json"
 	"fmt"
 	"github.com/logzio/logzio_terraform_client/users"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -19,7 +20,7 @@ func TestUsers_UpdateUser(t *testing.T) {
 		mux.HandleFunc(usersApiBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
 			assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(userId), 10))
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target users.CreateUpdateUser
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)
@@ -49,7 +50,7 @@ func TestUsers_UpdateUserApiFail(t *testing.T) {
 		mux.HandleFunc(usersApiBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
 			assert.Contains(t, r.URL.String(), strconv.FormatInt(int64(userId), 10))
-			jsonBytes, _ := ioutil.ReadAll(r.Body)
+			jsonBytes, _ := io.ReadAll(r.Body)
 			var target users.CreateUpdateUser
 			err = json.Unmarshal(jsonBytes, &target)
 			assert.NoError(t, err)

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,6 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/logzio/logzio_terraform_client/client"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -76,7 +75,7 @@ func CreateHttpRequestBytesResponse(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	jsonBytes, err := ioutil.ReadAll(resp.Body)
+	jsonBytes, err := io.ReadAll(resp.Body)
 
 	if !CheckValidStatus(resp, []int{serviceSuccess, serviceNoContent, serviceCreated}) {
 		return nil, fmt.Errorf("%d %s", resp.StatusCode, jsonBytes)


### PR DESCRIPTION
## Description 

- added missing fields from the sub account endpoint
  - `snapSearchRetentionDays` -create and update requests + sub account payload
  - `IsCapped`, `SharedGB`, `TotalTimeBasedDailyGB`, `IsOwner` - missing sub account payload fields
- added tests
- replaced deprecated method calls
  - `ioutil.ReadFile` >> `os.ReadFile `
  - `ioutil.ReadAll` >> `io.ReadAll `
- updated changelog
- add random id to import kibana object test, to prevent sequential test from failing without manual cleanup 

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
