### PR TITLE
[Feature] Add support for `MEASUREMENT` metric type in metrics rollup rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changes by Version
 
 <!-- next version -->
+## v1.27.1
+- Add support for `MEASUREMENT` metric type in metrics rollup rules
 ## v1.27.0
 - Add optional `name` field to Metrics drop filters and Metrics rollup rules APIs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes by Version
 
 <!-- next version -->
+## v1.27.0
+- Add optional `name` field to Metrics drop filters and Metrics rollup rules APIs
+
 ## v1.26.0
 - Add [Metrics rollup rules API](./metrics_rollup_rules/README.md)
 

--- a/drop_metrics/README.md
+++ b/drop_metrics/README.md
@@ -10,7 +10,7 @@ client, _ := drop_metrics.New(apiToken, baseUrl)
 active := true
 result, err := client.CreateDropMetric(drop_metrics.CreateUpdateDropMetric{
     AccountId: 1234,
-    Name:      "my-cpu-filter", // Optional: human-readable name
+    Name:      "my-cpu-filter",
     Active:    &active,
     Filter: drop_metrics.FilterObject{
         Operator: drop_metrics.OperatorAnd,

--- a/drop_metrics/README.md
+++ b/drop_metrics/README.md
@@ -10,6 +10,7 @@ client, _ := drop_metrics.New(apiToken, baseUrl)
 active := true
 result, err := client.CreateDropMetric(drop_metrics.CreateUpdateDropMetric{
     AccountId: 1234,
+    Name:      "my-cpu-filter", // Optional: human-readable name
     Active:    &active,
     Filter: drop_metrics.FilterObject{
         Operator: drop_metrics.OperatorAnd,
@@ -28,6 +29,7 @@ result, err := client.CreateDropMetric(drop_metrics.CreateUpdateDropMetric{
 active := true
 updateResult, err := client.UpdateDropMetric(filterId, drop_metrics.CreateUpdateDropMetric{
     AccountId: 1234,
+    Name:      "updated-cpu-filter", // Optional: update the name
     Active:    &active,
     Filter: drop_metrics.FilterObject{
         Operator: drop_metrics.OperatorAnd,
@@ -38,6 +40,18 @@ updateResult, err := client.UpdateDropMetric(filterId, drop_metrics.CreateUpdate
                 ComparisonFilter: drop_metrics.ComparisonEq,
             },
         },
+    },
+})
+
+// Search for filters by name
+searchResults, err := client.SearchDropMetrics(drop_metrics.SearchDropMetricsRequest{
+    Filter: &drop_metrics.SearchFilter{
+        AccountIds: []int64{1234},
+        SearchTerm: "cpu", // Optional: search filters by name
+    },
+    Pagination: &drop_metrics.Pagination{
+        PageNumber: 0,
+        PageSize:   10,
     },
 })
 ```

--- a/drop_metrics/bulk_create_drop_metrics_test.go
+++ b/drop_metrics/bulk_create_drop_metrics_test.go
@@ -110,7 +110,6 @@ func TestDropMetrics_BulkCreateDropMetricsNameTooLong(t *testing.T) {
 	defer teardown()
 
 	active := true
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	requests := []drop_metrics.CreateUpdateDropMetric{

--- a/drop_metrics/bulk_create_drop_metrics_test.go
+++ b/drop_metrics/bulk_create_drop_metrics_test.go
@@ -56,7 +56,9 @@ func TestDropMetrics_BulkCreateDropMetrics(t *testing.T) {
 	assert.NotNil(t, results)
 	assert.Len(t, results, 2)
 	assert.Equal(t, int64(1), results[0].Id)
+	assert.Equal(t, "bulk-filter-1", results[0].Name)
 	assert.Equal(t, int64(2), results[1].Id)
+	assert.Equal(t, "bulk-filter-2", results[1].Name)
 }
 
 func TestDropMetrics_BulkCreateDropMetricsEmptyArray(t *testing.T) {

--- a/drop_metrics/client_drop_metrics.go
+++ b/drop_metrics/client_drop_metrics.go
@@ -121,6 +121,10 @@ func validateCreateUpdateDropMetricRequest(req CreateUpdateDropMetric) error {
 		return fmt.Errorf("accountId must be set and greater than 0")
 	}
 
+	if len(req.Name) > 256 {
+		return fmt.Errorf("name must not exceed 256 characters")
+	}
+
 	if err := validateFilterObject(req.Filter); err != nil {
 		return fmt.Errorf("filter validation failed: %w", err)
 	}

--- a/drop_metrics/client_drop_metrics.go
+++ b/drop_metrics/client_drop_metrics.go
@@ -40,6 +40,7 @@ type DropMetricsClient struct {
 // CreateUpdateDropMetric represents the request payload for creating or updating a drop metric filter
 type CreateUpdateDropMetric struct {
 	AccountId int64        `json:"accountId"`
+	Name      string       `json:"name,omitempty"`
 	Active    *bool        `json:"active,omitempty"`
 	Filter    FilterObject `json:"filter"`
 }
@@ -66,6 +67,7 @@ type FilterExpression struct {
 type DropMetric struct {
 	Id         int64        `json:"id"`
 	AccountId  int64        `json:"accountId"`
+	Name       string       `json:"name,omitempty"`
 	Active     bool         `json:"active"`
 	Filter     FilterObject `json:"filter"`
 	CreatedAt  string       `json:"createdAt,omitempty"`
@@ -90,6 +92,7 @@ type SearchFilter struct {
 	AccountIds  []int64  `json:"accountIds,omitempty"`
 	MetricNames []string `json:"metricNames,omitempty"`
 	Active      *bool    `json:"active,omitempty"`
+	SearchTerm  string   `json:"searchTerm,omitempty"`
 }
 
 // Pagination represents pagination parameters

--- a/drop_metrics/create_drop_metrics_test.go
+++ b/drop_metrics/create_drop_metrics_test.go
@@ -114,7 +114,7 @@ func TestDropMetrics_SearchWithSearchTerm(t *testing.T) {
 	searchReq := drop_metrics.SearchDropMetricsRequest{
 		Filter: &drop_metrics.SearchFilter{
 			AccountIds: []int64{1234},
-			SearchTerm: "cpu-filter", // Test the new searchTerm field
+			SearchTerm: "cpu-filter",
 		},
 		Pagination: &drop_metrics.Pagination{
 			PageNumber: 0,

--- a/drop_metrics/create_drop_metrics_test.go
+++ b/drop_metrics/create_drop_metrics_test.go
@@ -168,7 +168,6 @@ func TestDropMetrics_CreateDropMetricNameTooLong(t *testing.T) {
 	defer teardown()
 
 	active := true
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	createReq := drop_metrics.CreateUpdateDropMetric{

--- a/drop_metrics/create_drop_metrics_test.go
+++ b/drop_metrics/create_drop_metrics_test.go
@@ -143,7 +143,7 @@ func TestDropMetrics_CreateDropMetricWithName(t *testing.T) {
 	active := true
 	createReq := drop_metrics.CreateUpdateDropMetric{
 		AccountId: 1234,
-		Name:      "test-drop-filter", // Test the new Name field
+		Name:      "test-drop-filter",
 		Active:    &active,
 		Filter: drop_metrics.FilterObject{
 			Operator: drop_metrics.OperatorAnd,
@@ -160,7 +160,7 @@ func TestDropMetrics_CreateDropMetricWithName(t *testing.T) {
 	result, err := underTest.CreateDropMetric(createReq)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, "my-drop-filter", result.Name) // Verify response includes name
+	assert.Equal(t, "my-drop-filter", result.Name)
 }
 
 func TestDropMetrics_CreateDropMetricNameTooLong(t *testing.T) {

--- a/drop_metrics/create_drop_metrics_test.go
+++ b/drop_metrics/create_drop_metrics_test.go
@@ -45,6 +45,7 @@ func TestDropMetrics_CreateDropMetric(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(1), result.Id)
 	assert.Equal(t, int64(1234), result.AccountId)
+	assert.Equal(t, "my-drop-filter", result.Name)
 	assert.True(t, result.Active)
 	assert.Equal(t, "AND", result.Filter.Operator)
 	assert.Len(t, result.Filter.Expression, 2)
@@ -98,4 +99,65 @@ func TestDropMetrics_CreateDropMetricValidationError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "accountId must be set and greater than 0")
+}
+
+func TestDropMetrics_SearchWithSearchTerm(t *testing.T) {
+	underTest, mux, teardown := setupDropMetricsTest()
+	defer teardown()
+
+	mux.HandleFunc("/v1/metrics-management/drop-filters/search", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("search_drop_metrics.json"))
+	})
+
+	searchReq := drop_metrics.SearchDropMetricsRequest{
+		Filter: &drop_metrics.SearchFilter{
+			AccountIds: []int64{1234},
+			SearchTerm: "cpu-filter", // Test the new searchTerm field
+		},
+		Pagination: &drop_metrics.Pagination{
+			PageNumber: 0,
+			PageSize:   10,
+		},
+	}
+
+	results, err := underTest.SearchDropMetrics(searchReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "searchable-drop-filter", results[0].Name)
+}
+
+func TestDropMetrics_CreateDropMetricWithName(t *testing.T) {
+	underTest, mux, teardown := setupDropMetricsTest()
+	defer teardown()
+
+	mux.HandleFunc("/v1/metrics-management/drop-filters", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("create_drop_metric.json"))
+	})
+
+	active := true
+	createReq := drop_metrics.CreateUpdateDropMetric{
+		AccountId: 1234,
+		Name:      "test-drop-filter", // Test the new Name field
+		Active:    &active,
+		Filter: drop_metrics.FilterObject{
+			Operator: drop_metrics.OperatorAnd,
+			Expression: []drop_metrics.FilterExpression{
+				{
+					Name:             "__name__",
+					Value:            "CpuUsage",
+					ComparisonFilter: drop_metrics.ComparisonEq,
+				},
+			},
+		},
+	}
+
+	result, err := underTest.CreateDropMetric(createReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "my-drop-filter", result.Name) // Verify response includes name
 }

--- a/drop_metrics/testdata/fixtures/bulk_create_drop_metrics.json
+++ b/drop_metrics/testdata/fixtures/bulk_create_drop_metrics.json
@@ -2,6 +2,7 @@
   {
     "id": 1,
     "accountId": 1234,
+    "name": "bulk-filter-1",
     "active": true,
     "filter": {
       "operator": "AND",
@@ -21,6 +22,7 @@
   {
     "id": 2,
     "accountId": 1235,
+    "name": "bulk-filter-2",
     "active": true,
     "filter": {
       "operator": "AND",

--- a/drop_metrics/testdata/fixtures/create_drop_metric.json
+++ b/drop_metrics/testdata/fixtures/create_drop_metric.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "accountId": 1234,
+  "name": "my-drop-filter",
   "active": true,
   "filter": {
     "operator": "AND",

--- a/drop_metrics/testdata/fixtures/search_drop_metrics.json
+++ b/drop_metrics/testdata/fixtures/search_drop_metrics.json
@@ -2,6 +2,7 @@
   {
     "id": 1,
     "accountId": 1234,
+    "name": "searchable-drop-filter",
     "active": true,
     "filter": {
       "operator": "AND",

--- a/drop_metrics/testdata/fixtures/update_drop_metric.json
+++ b/drop_metrics/testdata/fixtures/update_drop_metric.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "accountId": 1234,
+  "name": "updated-drop-filter",
   "active": false,
   "filter": {
     "operator": "AND",

--- a/drop_metrics/update_drop_metrics_test.go
+++ b/drop_metrics/update_drop_metrics_test.go
@@ -135,7 +135,6 @@ func TestDropMetrics_UpdateDropMetricNameTooLong(t *testing.T) {
 	defer teardown()
 
 	enabled := true
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	updateReq := drop_metrics.CreateUpdateDropMetric{

--- a/drop_metrics/update_drop_metrics_test.go
+++ b/drop_metrics/update_drop_metrics_test.go
@@ -45,6 +45,7 @@ func TestDropMetrics_UpdateDropMetric(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(1), result.Id)
 	assert.Equal(t, int64(1234), result.AccountId)
+	assert.Equal(t, "updated-drop-filter", result.Name)
 	assert.False(t, result.Active)
 	assert.Equal(t, "AND", result.Filter.Operator)
 	assert.Len(t, result.Filter.Expression, 2)

--- a/metrics_rollup_rules/README.md
+++ b/metrics_rollup_rules/README.md
@@ -42,7 +42,9 @@ searchResults, err := client.SearchRollupRules(metrics_rollup_rules.SearchRollup
 ```
 
 > [!NOTE]
-> The `update` method does not support updating the `AccountId` and `metricName` fields. If you need to change either, you must delete the existing rule and create a new one.
+> The delete operation returns HTTP 204 No Content on success. The client supports both 200 and 204 for backward compatibility.
+> 
+> Supported metric types include: GAUGE, COUNTER, DELTA_COUNTER, CUMULATIVE_COUNTER, and MEASUREMENT.
 
 | Function | Signature |
 |----|-----|

--- a/metrics_rollup_rules/README.md
+++ b/metrics_rollup_rules/README.md
@@ -10,11 +10,34 @@ Manage metrics rollup rules for your Logz.io account.
 client, _ := metrics_rollup_rules.New(apiToken, baseUrl)
 result, err := client.CreateRollupRule(metrics_rollup_rules.CreateUpdateRollupRule{
     AccountId:               1234,
+    Name:                    "my-cpu-rollup", // Optional: human-readable name
     MetricName:              "cpu_usage",
     MetricType:              metrics_rollup_rules.MetricTypeGauge,
     RollupFunction:          metrics_rollup_rules.AggLast,
     LabelsEliminationMethod: metrics_rollup_rules.LabelsExcludeBy,
     Labels:                  []string{"label1"},
+})
+
+// Update a rollup rule
+updateResult, err := client.UpdateRollupRule(ruleId, metrics_rollup_rules.CreateUpdateRollupRule{
+    Name:                    "updated-cpu-rollup", // Optional: update the name
+    MetricName:              "cpu_usage_updated",
+    MetricType:              metrics_rollup_rules.MetricTypeGauge,
+    RollupFunction:          metrics_rollup_rules.AggMax,
+    LabelsEliminationMethod: metrics_rollup_rules.LabelsExcludeBy,
+    Labels:                  []string{"label1", "label2"},
+})
+
+// Search for rollup rules by name
+searchResults, err := client.SearchRollupRules(metrics_rollup_rules.SearchRollupRulesRequest{
+    Filter: &metrics_rollup_rules.SearchFilter{
+        AccountIds: []int64{1234},
+        SearchTerm: "cpu", // Optional: search rules by name
+    },
+    Pagination: &metrics_rollup_rules.Pagination{
+        PageNumber: 0,
+        PageSize:   10,
+    },
 })
 ```
 

--- a/metrics_rollup_rules/client_metrics_rollup_rules.go
+++ b/metrics_rollup_rules/client_metrics_rollup_rules.go
@@ -31,6 +31,7 @@ const (
 	MetricTypeCounter           MetricType = "COUNTER"
 	MetricTypeDeltaCounter      MetricType = "DELTA_COUNTER"
 	MetricTypeCumulativeCounter MetricType = "CUMULATIVE_COUNTER"
+	MetricTypeMeasurement       MetricType = "MEASUREMENT"
 )
 
 type AggregationFunction string
@@ -234,6 +235,7 @@ func GetValidMetricType() []MetricType {
 		MetricTypeCounter,
 		MetricTypeDeltaCounter,
 		MetricTypeCumulativeCounter,
+		MetricTypeMeasurement,
 	}
 }
 

--- a/metrics_rollup_rules/client_metrics_rollup_rules.go
+++ b/metrics_rollup_rules/client_metrics_rollup_rules.go
@@ -90,6 +90,7 @@ type ComplexFilter struct {
 
 type RollupRule struct {
 	Id                      string              `json:"id"`
+	Name                    string              `json:"name,omitempty"`
 	AccountId               int64               `json:"accountId"`
 	MetricName              string              `json:"metricName,omitempty"`
 	MetricType              MetricType          `json:"metricType"`
@@ -109,6 +110,7 @@ type RollupRule struct {
 // CreateUpdateRollupRule represents the request payload for creating a rollup rule
 type CreateUpdateRollupRule struct {
 	AccountId               int64               `json:"accountId"`
+	Name                    string              `json:"name,omitempty"`
 	MetricName              string              `json:"metricName,omitempty"`
 	MetricType              MetricType          `json:"metricType"`
 	RollupFunction          AggregationFunction `json:"rollupFunction"`
@@ -131,6 +133,7 @@ type Pagination struct {
 type SearchFilter struct {
 	AccountIds  []int64  `json:"accountIds,omitempty"`
 	MetricNames []string `json:"metricNames,omitempty"`
+	SearchTerm  string   `json:"searchTerm,omitempty"`
 }
 
 type SearchRollupRulesRequest struct {

--- a/metrics_rollup_rules/client_metrics_rollup_rules.go
+++ b/metrics_rollup_rules/client_metrics_rollup_rules.go
@@ -163,6 +163,10 @@ func New(apiToken, baseUrl string) (*MetricsRollupRulesClient, error) {
 
 // validateCreateUpdateRollupRuleRequest validates the create rollup rule request
 func validateCreateUpdateRollupRuleRequest(req CreateUpdateRollupRule) error {
+	if len(req.Name) > 256 {
+		return fmt.Errorf("name must not exceed 256 characters")
+	}
+
 	if req.MetricType == "" {
 		return fmt.Errorf("metricType must be set")
 	}

--- a/metrics_rollup_rules/client_metrics_rollup_rules_delete.go
+++ b/metrics_rollup_rules/client_metrics_rollup_rules_delete.go
@@ -11,6 +11,7 @@ const (
 	deleteMetricsRollupRulesServiceUrl = metricsRollupRulesServiceEndpoint + "/%s"
 	deleteRollupRuleMethod             = http.MethodDelete
 	deleteRollupRuleSuccess            = http.StatusOK
+	deleteRollupRuleNoContent          = http.StatusNoContent
 	deleteRollupRuleNotFound           = http.StatusNotFound
 )
 
@@ -26,7 +27,7 @@ func (c *MetricsRollupRulesClient) DeleteRollupRule(rollupRuleId string) error {
 		HttpMethod:   deleteRollupRuleMethod,
 		Url:          url,
 		Body:         nil,
-		SuccessCodes: []int{deleteRollupRuleSuccess},
+		SuccessCodes: []int{deleteRollupRuleSuccess, deleteRollupRuleNoContent},
 		NotFoundCode: deleteRollupRuleNotFound,
 		ResourceId:   rollupRuleId,
 		ApiAction:    operationDeleteMetricsRollupRule,

--- a/metrics_rollup_rules/metrics_rollup_rules_bulk_create_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_bulk_create_test.go
@@ -85,7 +85,6 @@ func TestBulkCreateRollupRulesNameTooLong(t *testing.T) {
 	underTest, _, teardown := setupMetricsRollupRulesTest()
 	defer teardown()
 
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	requests := []metrics_rollup_rules.CreateUpdateRollupRule{

--- a/metrics_rollup_rules/metrics_rollup_rules_bulk_create_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_bulk_create_test.go
@@ -46,7 +46,9 @@ func TestBulkCreateRollupRulesSuccess(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Len(t, res, 2)
 		assert.Equal(t, "a", res[0].Id)
+		assert.Equal(t, "bulk-rollup-rule-1", res[0].Name)
 		assert.Equal(t, "b", res[1].Id)
+		assert.Equal(t, "bulk-rollup-rule-2", res[1].Name)
 	}
 }
 

--- a/metrics_rollup_rules/metrics_rollup_rules_create_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_create_test.go
@@ -94,7 +94,7 @@ func TestCreateRollupRuleWithName(t *testing.T) {
 
 		request := metrics_rollup_rules.CreateUpdateRollupRule{
 			AccountId:               1,
-			Name:                    "test-rollup-rule", // Test the new Name field
+			Name:                    "test-rollup-rule",
 			MetricName:              "cpu",
 			MetricType:              metrics_rollup_rules.MetricTypeGauge,
 			RollupFunction:          metrics_rollup_rules.AggLast,
@@ -105,7 +105,7 @@ func TestCreateRollupRuleWithName(t *testing.T) {
 		res, err := underTest.CreateRollupRule(request)
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
-		assert.Equal(t, "my-rollup-rule", res.Name) // Verify response includes name
+		assert.Equal(t, "my-rollup-rule", res.Name)
 	}
 }
 

--- a/metrics_rollup_rules/metrics_rollup_rules_create_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_create_test.go
@@ -113,7 +113,6 @@ func TestCreateRollupRuleNameTooLong(t *testing.T) {
 	underTest, _, teardown := setupMetricsRollupRulesTest()
 	defer teardown()
 
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	request := metrics_rollup_rules.CreateUpdateRollupRule{

--- a/metrics_rollup_rules/metrics_rollup_rules_create_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_create_test.go
@@ -34,6 +34,7 @@ func TestCreateRollupRuleSuccess(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, "abc", res.Id)
+		assert.Equal(t, "my-rollup-rule", res.Name)
 		assert.Equal(t, int64(1), res.AccountId)
 		assert.Equal(t, metrics_rollup_rules.MetricTypeGauge, res.MetricType)
 		assert.Equal(t, metrics_rollup_rules.AggLast, res.RollupFunction)
@@ -75,5 +76,34 @@ func TestCreateRollupRuleApiFailed(t *testing.T) {
 		res, err := underTest.CreateRollupRule(request)
 		assert.Error(t, err)
 		assert.Nil(t, res)
+	}
+}
+
+func TestCreateRollupRuleWithName(t *testing.T) {
+	underTest, err, teardown := setupMetricsRollupRulesTest()
+	defer teardown()
+
+	if assert.NoError(t, err) {
+		mux.HandleFunc(metricsRollupRulesPath, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, fixture("create_metrics_rollup_rule.json"))
+		})
+
+		request := metrics_rollup_rules.CreateUpdateRollupRule{
+			AccountId:               1,
+			Name:                    "test-rollup-rule", // Test the new Name field
+			MetricName:              "cpu",
+			MetricType:              metrics_rollup_rules.MetricTypeGauge,
+			RollupFunction:          metrics_rollup_rules.AggLast,
+			LabelsEliminationMethod: metrics_rollup_rules.LabelsExcludeBy,
+			Labels:                  []string{"x"},
+		}
+
+		res, err := underTest.CreateRollupRule(request)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, "my-rollup-rule", res.Name) // Verify response includes name
 	}
 }

--- a/metrics_rollup_rules/metrics_rollup_rules_delete_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_delete_test.go
@@ -15,7 +15,7 @@ func TestDeleteRollupRuleSuccess(t *testing.T) {
 	if assert.NoError(t, err) {
 		mux.HandleFunc(metricsRollupRulesPath+"/abc", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 		})
 
 		err := underTest.DeleteRollupRule("abc")

--- a/metrics_rollup_rules/metrics_rollup_rules_get_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_get_test.go
@@ -24,6 +24,7 @@ func TestGetRollupRuleSuccess(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, "abc", res.Id)
+		assert.Equal(t, "get-rollup-rule", res.Name)
 	}
 }
 

--- a/metrics_rollup_rules/metrics_rollup_rules_search_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_search_test.go
@@ -45,3 +45,34 @@ func TestSearchRollupRulesApiFailed(t *testing.T) {
 		assert.Nil(t, res)
 	}
 }
+
+func TestSearchRollupRulesWithSearchTerm(t *testing.T) {
+	underTest, err, teardown := setupMetricsRollupRulesTest()
+	defer teardown()
+
+	if assert.NoError(t, err) {
+		mux.HandleFunc(metricsRollupRulesPath+"/search", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[{"id":"a","name":"cpu-rollup-rule","accountId":1,"metricType":"GAUGE","rollupFunction":"LAST","labelsEliminationMethod":"EXCLUDE_BY","labels":["x"],"isDeleted":false,"dropOriginalMetric":false,"version":1}]`)
+		})
+
+		searchReq := metrics_rollup_rules.SearchRollupRulesRequest{
+			Filter: &metrics_rollup_rules.SearchFilter{
+				AccountIds: []int64{1},
+				SearchTerm: "cpu-rollup", // Test the new searchTerm field
+			},
+			Pagination: &metrics_rollup_rules.Pagination{
+				PageNumber: 0,
+				PageSize:   10,
+			},
+		}
+
+		res, err := underTest.SearchRollupRules(searchReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Len(t, res, 1)
+		assert.Equal(t, "cpu-rollup-rule", res[0].Name)
+	}
+}

--- a/metrics_rollup_rules/metrics_rollup_rules_update_integration_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_update_integration_test.go
@@ -22,7 +22,7 @@ func TestIntegrationMetricsRollupRules_UpdateRollupRule(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			req.MetricType = metrics_rollup_rules.MetricTypeCounter
-			
+
 			updated, err := underTest.UpdateRollupRule(created.Id, req)
 			if assert.NoError(t, err) && assert.NotNil(t, updated) {
 				assert.Equal(t, req.MetricType, updated.MetricType)

--- a/metrics_rollup_rules/metrics_rollup_rules_update_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_update_test.go
@@ -3,6 +3,7 @@ package metrics_rollup_rules_test
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/logzio/logzio_terraform_client/metrics_rollup_rules"
@@ -47,6 +48,28 @@ func TestUpdateRollupRuleValidation(t *testing.T) {
 
 	_, err = underTest.UpdateRollupRule("abc", metrics_rollup_rules.CreateUpdateRollupRule{})
 	assert.Error(t, err)
+}
+
+func TestUpdateRollupRuleNameTooLong(t *testing.T) {
+	underTest, _, teardown := setupMetricsRollupRulesTest()
+	defer teardown()
+
+	// Create a name that exceeds 256 characters
+	longName := strings.Repeat("a", 257)
+
+	request := metrics_rollup_rules.CreateUpdateRollupRule{
+		Name:                    longName,
+		MetricName:              "cpu2",
+		MetricType:              metrics_rollup_rules.MetricTypeCounter,
+		RollupFunction:          metrics_rollup_rules.AggMax,
+		LabelsEliminationMethod: metrics_rollup_rules.LabelsExcludeBy,
+		Labels:                  []string{"host", "region"},
+	}
+
+	res, err := underTest.UpdateRollupRule("abc", request)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "name must not exceed 256 characters")
 }
 
 func TestUpdateRollupRuleApiFailed(t *testing.T) {

--- a/metrics_rollup_rules/metrics_rollup_rules_update_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_update_test.go
@@ -54,7 +54,6 @@ func TestUpdateRollupRuleNameTooLong(t *testing.T) {
 	underTest, _, teardown := setupMetricsRollupRulesTest()
 	defer teardown()
 
-	// Create a name that exceeds 256 characters
 	longName := strings.Repeat("a", 257)
 
 	request := metrics_rollup_rules.CreateUpdateRollupRule{

--- a/metrics_rollup_rules/metrics_rollup_rules_update_test.go
+++ b/metrics_rollup_rules/metrics_rollup_rules_update_test.go
@@ -33,6 +33,7 @@ func TestUpdateRollupRuleSuccess(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, "abc", res.Id)
+		assert.Equal(t, "updated-rollup-rule", res.Name)
 		assert.Equal(t, "cpu2", res.MetricName)
 	}
 }

--- a/metrics_rollup_rules/testdata/fixtures/bulk_create_metrics_rollup_rules.json
+++ b/metrics_rollup_rules/testdata/fixtures/bulk_create_metrics_rollup_rules.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "a",
+    "name": "bulk-rollup-rule-1",
     "accountId": 1,
     "metricType": "GAUGE",
     "rollupFunction": "LAST",
@@ -14,6 +15,7 @@
   },
   {
     "id": "b",
+    "name": "bulk-rollup-rule-2",
     "accountId": 1,
     "metricType": "GAUGE",
     "rollupFunction": "COUNT",

--- a/metrics_rollup_rules/testdata/fixtures/create_metrics_rollup_rule.json
+++ b/metrics_rollup_rules/testdata/fixtures/create_metrics_rollup_rule.json
@@ -1,5 +1,6 @@
 {
   "id": "abc",
+  "name": "my-rollup-rule",
   "accountId": 1,
   "metricName": "cpu",
   "metricType": "GAUGE",

--- a/metrics_rollup_rules/testdata/fixtures/get_metrics_rollup_rule.json
+++ b/metrics_rollup_rules/testdata/fixtures/get_metrics_rollup_rule.json
@@ -1,5 +1,6 @@
 {
   "id": "abc",
+  "name": "get-rollup-rule",
   "accountId": 1,
   "metricName": "cpu",
   "metricType": "GAUGE",

--- a/metrics_rollup_rules/testdata/fixtures/update_metrics_rollup_rule.json
+++ b/metrics_rollup_rules/testdata/fixtures/update_metrics_rollup_rule.json
@@ -1,5 +1,6 @@
 {
   "id": "abc",
+  "name": "updated-rollup-rule",
   "accountId": 1,
   "metricName": "cpu2",
   "metricType": "GAUGE",


### PR DESCRIPTION
## Description 

- Add support for `MEASUREMENT` metric type in metrics rollup rules


## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
