### PR TITLE
[Feat] Add optional `dropPolicy` field + Remove name length validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changes by Version
 
 <!-- next version -->
+## v1.27.4
+- Drop metrics:
+  - Add optional `dropPolicy` field with values `DROP_BEFORE_PROCESSING` (default) and `DROP_BEFORE_STORING`
+  - Remove name length validation - the `name` field no longer has a 256-character limit
 ## v1.27.3
 - Metrics rollup rules:
   - Support all aggregation types for `MEASUREMENT`

--- a/drop_metrics/README.md
+++ b/drop_metrics/README.md
@@ -12,6 +12,7 @@ result, err := client.CreateDropMetric(drop_metrics.CreateUpdateDropMetric{
     AccountId: 1234,
     Name:      "my-cpu-filter",
     Active:    &active,
+    DropPolicy: drop_metrics.DropPolicyBeforeProcessing, // optional, defaults to DROP_BEFORE_PROCESSING
     Filter: drop_metrics.FilterObject{
         Operator: drop_metrics.OperatorAnd,
         Expression: []drop_metrics.FilterExpression{
@@ -31,6 +32,7 @@ updateResult, err := client.UpdateDropMetric(filterId, drop_metrics.CreateUpdate
     AccountId: 1234,
     Name:      "updated-cpu-filter", // Optional: update the name
     Active:    &active,
+    DropPolicy: drop_metrics.DropPolicyBeforeStoring,
     Filter: drop_metrics.FilterObject{
         Operator: drop_metrics.OperatorAnd,
         Expression: []drop_metrics.FilterExpression{
@@ -63,6 +65,12 @@ Currently supported comparison operators:
 - `NOT_EQ` - Not equal comparison
 - `REGEX_MATCH` - Regular expression match
 - `REGEX_NO_MATCH` - Regular expression no match
+
+## Drop Policies
+
+Drop policies determine when metrics are dropped:
+- `DROP_BEFORE_PROCESSING` (default) - drops metrics before processing
+- `DROP_BEFORE_STORING` - drops metrics after processing, before storing in Thanos
 
 | Function | Signature |
 |----------|-----------|

--- a/drop_metrics/README.md
+++ b/drop_metrics/README.md
@@ -72,6 +72,8 @@ Drop policies determine when metrics are dropped:
 - `DROP_BEFORE_PROCESSING` (default) - drops metrics before processing
 - `DROP_BEFORE_STORING` - drops metrics after processing, before storing in Thanos
 
+## API Functions
+
 | Function | Signature |
 |----------|-----------|
 | create drop metric | `func (c *DropMetricsClient) CreateDropMetric(req CreateDropMetric) (*DropMetric, error)` |

--- a/drop_metrics/create_drop_metrics_test.go
+++ b/drop_metrics/create_drop_metrics_test.go
@@ -3,7 +3,6 @@ package drop_metrics_test
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/logzio/logzio_terraform_client/drop_metrics"
@@ -48,6 +47,7 @@ func TestDropMetrics_CreateDropMetric(t *testing.T) {
 	assert.Equal(t, int64(1234), result.AccountId)
 	assert.Equal(t, "my-drop-filter", result.Name)
 	assert.True(t, result.Active)
+	assert.Equal(t, "DROP_BEFORE_PROCESSING", result.DropPolicy)
 	assert.Equal(t, "AND", result.Filter.Operator)
 	assert.Len(t, result.Filter.Expression, 2)
 }
@@ -128,6 +128,7 @@ func TestDropMetrics_SearchWithSearchTerm(t *testing.T) {
 	assert.NotNil(t, results)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "searchable-drop-filter", results[0].Name)
+	assert.Equal(t, "DROP_BEFORE_PROCESSING", results[0].DropPolicy)
 }
 
 func TestDropMetrics_CreateDropMetricWithName(t *testing.T) {
@@ -163,17 +164,50 @@ func TestDropMetrics_CreateDropMetricWithName(t *testing.T) {
 	assert.Equal(t, "my-drop-filter", result.Name)
 }
 
-func TestDropMetrics_CreateDropMetricNameTooLong(t *testing.T) {
+func TestDropMetrics_CreateDropMetricWithDropPolicy(t *testing.T) {
+	underTest, mux, teardown := setupDropMetricsTest()
+	defer teardown()
+
+	mux.HandleFunc("/v1/metrics-management/drop-filters", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, fixture("update_drop_metric.json")) // Uses DROP_BEFORE_STORING
+	})
+
+	active := true
+	createReq := drop_metrics.CreateUpdateDropMetric{
+		AccountId:  1234,
+		Name:       "test-drop-filter",
+		Active:     &active,
+		DropPolicy: drop_metrics.DropPolicyBeforeStoring,
+		Filter: drop_metrics.FilterObject{
+			Operator: drop_metrics.OperatorAnd,
+			Expression: []drop_metrics.FilterExpression{
+				{
+					Name:             "__name__",
+					Value:            "CpuUsage",
+					ComparisonFilter: drop_metrics.ComparisonEq,
+				},
+			},
+		},
+	}
+
+	result, err := underTest.CreateDropMetric(createReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "DROP_BEFORE_STORING", result.DropPolicy)
+}
+
+func TestDropMetrics_CreateDropMetricInvalidDropPolicy(t *testing.T) {
 	underTest, _, teardown := setupDropMetricsTest()
 	defer teardown()
 
 	active := true
-	longName := strings.Repeat("a", 257)
-
 	createReq := drop_metrics.CreateUpdateDropMetric{
-		AccountId: 1234,
-		Name:      longName,
-		Active:    &active,
+		AccountId:  1234,
+		Name:       "test-drop-filter",
+		Active:     &active,
+		DropPolicy: "INVALID_POLICY",
 		Filter: drop_metrics.FilterObject{
 			Operator: drop_metrics.OperatorAnd,
 			Expression: []drop_metrics.FilterExpression{
@@ -189,5 +223,5 @@ func TestDropMetrics_CreateDropMetricNameTooLong(t *testing.T) {
 	result, err := underTest.CreateDropMetric(createReq)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "name must not exceed 256 characters")
+	assert.Contains(t, err.Error(), "dropPolicy must be one of")
 }

--- a/drop_metrics/testdata/fixtures/bulk_create_drop_metrics.json
+++ b/drop_metrics/testdata/fixtures/bulk_create_drop_metrics.json
@@ -4,6 +4,7 @@
     "accountId": 1234,
     "name": "bulk-filter-1",
     "active": true,
+    "dropPolicy": "DROP_BEFORE_PROCESSING",
     "filter": {
       "operator": "AND",
       "expression": [
@@ -24,6 +25,7 @@
     "accountId": 1235,
     "name": "bulk-filter-2",
     "active": true,
+    "dropPolicy": "DROP_BEFORE_STORING",
     "filter": {
       "operator": "AND",
       "expression": [

--- a/drop_metrics/testdata/fixtures/create_drop_metric.json
+++ b/drop_metrics/testdata/fixtures/create_drop_metric.json
@@ -3,6 +3,7 @@
   "accountId": 1234,
   "name": "my-drop-filter",
   "active": true,
+  "dropPolicy": "DROP_BEFORE_PROCESSING",
   "filter": {
     "operator": "AND",
     "expression": [

--- a/drop_metrics/testdata/fixtures/search_drop_metrics.json
+++ b/drop_metrics/testdata/fixtures/search_drop_metrics.json
@@ -4,6 +4,7 @@
     "accountId": 1234,
     "name": "searchable-drop-filter",
     "active": true,
+    "dropPolicy": "DROP_BEFORE_PROCESSING",
     "filter": {
       "operator": "AND",
       "expression": [

--- a/drop_metrics/testdata/fixtures/update_drop_metric.json
+++ b/drop_metrics/testdata/fixtures/update_drop_metric.json
@@ -3,6 +3,7 @@
   "accountId": 1234,
   "name": "updated-drop-filter",
   "active": false,
+  "dropPolicy": "DROP_BEFORE_STORING",
   "filter": {
     "operator": "AND",
     "expression": [


### PR DESCRIPTION
## Description 

## v1.27.4
- Drop metrics:
  - Add optional `dropPolicy` field with values `DROP_BEFORE_PROCESSING` (default) and `DROP_BEFORE_STORING`
  - Remove name length validation - the `name` field no longer has a 256-character limit

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
