### PR TITLE
[Feature]: Add optional description field to drop_filters

### DIFF
--- a/drop_filters/client_drop_filters.go
+++ b/drop_filters/client_drop_filters.go
@@ -23,6 +23,7 @@ type DropFiltersClient struct {
 
 type CreateDropFilter struct {
 	LogType         string                 `json:"logType,omitempty"`
+	Description     string                 `json:"description,omitempty"`
 	FieldConditions []FieldConditionObject `json:"fieldConditions"`
 	ThresholdInGB   float64                `json:"thresholdInGB,omitempty"`
 }
@@ -36,6 +37,7 @@ type DropFilter struct {
 	Id             string                 `json:"id"`
 	Active         bool                   `json:"active"`
 	LogType        string                 `json:"logType"`
+	Description    string                 `json:"description"`
 	FieldCondition []FieldConditionObject `json:"fieldConditions"`
 	ThresholdInGB  float64                `json:"thresholdInGB,omitempty"`
 }

--- a/drop_filters/create_drop_filters_integration_test.go
+++ b/drop_filters/create_drop_filters_integration_test.go
@@ -18,6 +18,7 @@ func TestIntegrationDropFilter_CreateDropFilter(t *testing.T) {
 			defer underTest.DeleteDropFilter(dropFilter.Id)
 			assert.NotEmpty(t, dropFilter.Id)
 			assert.NotEmpty(t, dropFilter.LogType)
+			assert.NotEmpty(t, dropFilter.Description)
 			assert.NotEmpty(t, dropFilter.FieldCondition)
 		}
 	}
@@ -46,6 +47,21 @@ func TestIntegrationDropFilters_CreateDropFilterNoLogType(t *testing.T) {
 	if assert.NoError(t, err) {
 		createDropFilter := getCreateDropFilter()
 		createDropFilter.LogType = ""
+		dropFilter, err := underTest.CreateDropFilter(createDropFilter)
+
+		time.Sleep(2 * time.Second)
+		if assert.NoError(t, err) && assert.NotNil(t, dropFilter) {
+			defer underTest.DeleteDropFilter(dropFilter.Id)
+		}
+	}
+}
+
+func TestIntegrationDropFilter_CreateDropFilterNoDescription(t *testing.T) {
+	underTest, err := setupDropFiltersIntegrationTest()
+
+	if assert.NoError(t, err) {
+		createDropFilter := getCreateDropFilter()
+		createDropFilter.Description = ""
 		dropFilter, err := underTest.CreateDropFilter(createDropFilter)
 
 		time.Sleep(2 * time.Second)

--- a/drop_filters/create_drop_filters_integration_test.go
+++ b/drop_filters/create_drop_filters_integration_test.go
@@ -64,8 +64,7 @@ func TestIntegrationDropFilter_CreateDropFilterNoDescription(t *testing.T) {
 		createDropFilter.Description = ""
 		dropFilter, err := underTest.CreateDropFilter(createDropFilter)
 
-		time.Sleep(2 * time.Second)
-		if assert.NoError(t, err) && assert.NotNil(t, dropFilter) {
+	if assert.NoError(t, err) && assert.NotNil(t, dropFilter) {
 			defer underTest.DeleteDropFilter(dropFilter.Id)
 		}
 	}

--- a/drop_filters/create_drop_filters_test.go
+++ b/drop_filters/create_drop_filters_test.go
@@ -145,6 +145,7 @@ func TestDropFilters_CreateDropFilterWithZeroThreshold(t *testing.T) {
 				"id": "some-drop-filter-id",
 				"active": true,
 				"logType": "some_type",
+				"description": "some_description",
 				"fieldConditions": [
 					{
 						"fieldName": "some_field",

--- a/drop_filters/drop_filter_test.go
+++ b/drop_filters/drop_filter_test.go
@@ -52,6 +52,7 @@ func getCreateDropFilter() drop_filters.CreateDropFilter {
 
 	return drop_filters.CreateDropFilter{
 		LogType:         "some_type",
+		Description:     "some_description",
 		FieldConditions: []drop_filters.FieldConditionObject{fieldCondition},
 	}
 }

--- a/drop_filters/retrieve_drop_filters_test.go
+++ b/drop_filters/retrieve_drop_filters_test.go
@@ -28,11 +28,13 @@ func TestDropFilters_RetrieveDropFilters(t *testing.T) {
 		// Test first drop filter
 		assert.Equal(t, "some-drop-filter-id", dropFilters[0].Id)
 		assert.True(t, dropFilters[0].Active)
+		assert.Equal(t, "some_description", dropFilters[0].Description)
 		assert.Equal(t, 10.5, dropFilters[0].ThresholdInGB)
 
 		// Test second drop filter
 		assert.Equal(t, "another-drop-filter-id", dropFilters[1].Id)
 		assert.True(t, dropFilters[1].Active)
+		assert.Equal(t, "other_description", dropFilters[1].Description)
 		assert.Equal(t, 5.0, dropFilters[1].ThresholdInGB)
 	}
 }

--- a/drop_filters/testdata/fixtures/activate_drop_filter.json
+++ b/drop_filters/testdata/fixtures/activate_drop_filter.json
@@ -2,6 +2,7 @@
   "id": "some-drop-filter-id",
   "active": true,
   "logType": "some_type",
+  "description": "some_description",
   "fieldConditions": [
     {
       "fieldName": "some_field",

--- a/drop_filters/testdata/fixtures/create_drop_filter.json
+++ b/drop_filters/testdata/fixtures/create_drop_filter.json
@@ -2,6 +2,7 @@
   "id": "some-drop-filter-id",
   "active": true,
   "logType": "some_type",
+  "description": "some_description",
   "fieldConditions": [
     {
       "fieldName": "some_field",

--- a/drop_filters/testdata/fixtures/deactivate_drop_filter.json
+++ b/drop_filters/testdata/fixtures/deactivate_drop_filter.json
@@ -2,6 +2,7 @@
   "id": "some-drop-filter-id",
   "active": false,
   "logType": "some_type",
+  "description": "some_description",
   "fieldConditions": [
     {
       "fieldName": "some_field",

--- a/drop_filters/testdata/fixtures/delete_drop_filter.json
+++ b/drop_filters/testdata/fixtures/delete_drop_filter.json
@@ -2,6 +2,7 @@
   "id": "some-drop-filter-id",
   "active": true,
   "logType": "some_type",
+  "description": "some_description",
   "fieldConditions": [
     {
       "fieldName": "some_field",

--- a/drop_filters/testdata/fixtures/retrieve_drop_filter.json
+++ b/drop_filters/testdata/fixtures/retrieve_drop_filter.json
@@ -3,6 +3,7 @@
     "id": "some-drop-filter-id",
     "active": true,
     "logType": "some_type",
+    "description": "some_description",
     "fieldConditions": [
       {
         "fieldName": "some_field",
@@ -15,6 +16,7 @@
     "id": "another-drop-filter-id",
     "active": true,
     "logType": "other_type",
+    "description": "other_description",
     "fieldConditions": [
       {
         "fieldName": "field",


### PR DESCRIPTION
## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

This PR adds the missing, but optional, `description` field to `drop_filters`. The goal is to support that field in the [terraform-provider-logzio](https://github.com/logzio/terraform-provider-logzio) as well.

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
